### PR TITLE
global: analysispreservation.cern.ch

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -3,20 +3,20 @@
 ==============
 
 Any contribution, bug report, feature request and code contributions are
-encouraged and welcome, so please go ahead and don't withhold feedback! 
+encouraged and welcome, so please go ahead and don't withhold feedback!
 
 Bug Reports and Feature Requests
 ================================
 
 If you find a bug or have a feature request, please search for
 `already reported problems
-<https://github.com/cernanalysispreservation/analysis-preservation.cern.ch/issues>`_
+<https://github.com/cernanalysispreservation/analysispreservation.cern.ch/issues>`_
 before submitting a new issue. Also, remember to set labels to
 indicate what you're filing an issue for.
 
 If you would like to take a more active part in the CERN Analysis
 Preservation developments, you can `watch ongoing discussions
-<https://github.com/cernanalysispreservation/analysis-preservation.cern.ch/notifications>`_
+<https://github.com/cernanalysispreservation/analysispreservation.cern.ch/notifications>`_
 and `become part of the team
 <https://github.com/orgs/cernanalysispreservation/teams>`_.
 
@@ -30,13 +30,13 @@ We follow a typical `GitHub flow
 2. Start a new topical branch for any contribution. Give it a
    descriptive name, say ``fix-CMS-schema-mappings``.
 3. Create logically separate commits for logically separate things
-   
+
    Remember, it is a lot easier to squash commits into one than it is
    to break them apart.
    If you are unsure what to do, mind the following based on the
-   `official Invenio documentation 
+   `official Invenio documentation
    <https://invenio.readthedocs.io/en/latest/technology/git.html#r1-remarks-on-commit-history>`_:
-   
+
    Split the commit
      * if the same commit addresses more than one logically separate
        problem
@@ -56,7 +56,7 @@ We follow a typical `GitHub flow
    the respective issue.
 5. Test your branch on a local site and check the conformity of your
    commit messages with kwalitee, see the section on
-   `Formating Commit Messages`_. You can also check out `this blog post 
+   `Formating Commit Messages`_. You can also check out `this blog post
    <http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html>`_
    on commit messages.
 7. If everything works as expected, issue a pull request.
@@ -90,7 +90,7 @@ The format required by kwalitee follows the structure indicated below:
     Signed-off-by YOURSELF
 
 ``KEYWORD`` needs to be one of
-`these <https://github.com/cernanalysispreservation/analysis-preservation.cern.ch/blob/c4446015db6598a310b874371c8f5c62ba6f52ee/.kwalitee.yml>`_,
+`these <https://github.com/cernanalysispreservation/analysispreservation.cern.ch/blob/c4446015db6598a310b874371c8f5c62ba6f52ee/.kwalitee.yml>`_,
 according to the type of change that you're introducing.
 
 To create the ``Signed-off-by`` with your name and email as configured
@@ -106,5 +106,5 @@ Chatroom
 ========
 
 Our chatroom is on `gitter
-<https://gitter.im/cernanalysispreservation/analysis-preservation.cern.ch>`_,
+<https://gitter.im/cernanalysispreservation/analysispreservation.cern.ch>`_,
 it's open to everyone so feel free to join the conversation.

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -86,7 +86,7 @@ Let's start by cloning the repository:
 
 .. code-block:: shell
 
-   git clone https://github.com/cernanalysispreservation/analysis-preservation.cern.ch.git cap
+   git clone https://github.com/cernanalysispreservation/analysispreservation.cern.ch.git cap
 
 All else will be installed inside a python *virtualenv* for easy
 maintenance and encapsulation of the libraries required. From inside

--- a/README.rst
+++ b/README.rst
@@ -1,13 +1,13 @@
-.. image:: https://travis-ci.org/cernanalysispreservation/analysis-preservation.cern.ch.png
-   :target: https://travis-ci.org/cernanalysispreservation/analysis-preservation.cern.ch
+.. image:: https://travis-ci.org/cernanalysispreservation/analysispreservation.cern.ch.png
+   :target: https://travis-ci.org/cernanalysispreservation/analysispreservation.cern.ch
 .. image:: https://badges.gitter.im/Join%20Chat.svg
-   :target: https://gitter.im/cernanalysispreservation/analysis-preservation.cern.ch?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
+   :target: https://gitter.im/cernanalysispreservation/analysispreservation.cern.ch?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge
 
 About
 -----
 
-This is source code behind `https://analysis-preservation.cern.ch/
-<https://analysis-preservation.cern.ch>`_.  This source code overlay
+This is source code behind `https://analysispreservation.cern.ch/
+<https://analysispreservation.cern.ch>`_.  This source code overlay
 installs on top of `Invenio
 <https://github.com/inveniosoftware/invenio>`_ digital library
 platform.

--- a/cap/jsonschemas/definitions/ATLASPublication-v0.0.1.json
+++ b/cap/jsonschemas/definitions/ATLASPublication-v0.0.1.json
@@ -17,7 +17,7 @@
       "description": "Identifier numbers for the publication, e.g. arXiv ID or CDS ID",
       "type": "array",
       "items": {
-        "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/Identifiers-v0.0.1.json"
+        "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/Identifiers-v0.0.1.json"
       }
     },
     "url": {

--- a/cap/jsonschemas/definitions/ATLASWorkflows-v0.0.1.json
+++ b/cap/jsonschemas/definitions/ATLASWorkflows-v0.0.1.json
@@ -11,7 +11,7 @@
 			},
 			"workflow": {
 				"oneOf":[{
-					"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/workflow-schema-v0.0.1.json"
+					"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/workflow-schema-v0.0.1.json"
 				}]
 			}
 		}

--- a/cap/jsonschemas/definitions/ATLASWorkflows_no_circ_refs-v0.0.1.json
+++ b/cap/jsonschemas/definitions/ATLASWorkflows_no_circ_refs-v0.0.1.json
@@ -11,7 +11,7 @@
 			},
 			"workflow": {
 				"oneOf":[{
-					"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/workflow-schema_no_circ_refs-v0.0.1.json"
+					"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/workflow-schema_no_circ_refs-v0.0.1.json"
 				}]
 			}
 		}

--- a/cap/jsonschemas/definitions/CMSAuxiliaryMeasurements-v0.0.1.json
+++ b/cap/jsonschemas/definitions/CMSAuxiliaryMeasurements-v0.0.1.json
@@ -13,10 +13,10 @@
       "type": "string"
     },
     "code_base": {
-      "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/CMSUserCode-v0.0.1.json"
+      "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/CMSUserCode-v0.0.1.json"
     },
     "n_tuple": {
-      "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/CMSInputCodeOutput-v0.0.1.json"
+      "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/CMSInputCodeOutput-v0.0.1.json"
     },
     "detector_final_state": {
       "title": "Event Selection",

--- a/cap/jsonschemas/definitions/CMSMainMeasurements-v0.0.1.json
+++ b/cap/jsonschemas/definitions/CMSMainMeasurements-v0.0.1.json
@@ -17,10 +17,10 @@
       "type": "string"
     },
     "code_base": {
-      "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/CMSUserCode-v0.0.1.json"
+      "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/CMSUserCode-v0.0.1.json"
     },
     "n_tuple": {
-      "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/CMSInputCodeOutput-v0.0.1.json"
+      "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/CMSInputCodeOutput-v0.0.1.json"
     },
     "detector_final_state": {
       "title": "Event Selection",

--- a/cap/jsonschemas/definitions/LHCbWorkflows.json
+++ b/cap/jsonschemas/definitions/LHCbWorkflows.json
@@ -11,7 +11,7 @@
 			},
 			"workflow": {
 				"oneOf":[{
-					"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/workflow-schema-v0.0.1.json"
+					"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/workflow-schema-v0.0.1.json"
 				}]
 			}
 		}

--- a/cap/jsonschemas/definitions/MonteCarloBackgroundDataset-v0.0.1.json
+++ b/cap/jsonschemas/definitions/MonteCarloBackgroundDataset-v0.0.1.json
@@ -35,7 +35,7 @@
           "description": "",
           "type": "array",
           "items": {
-            "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/Identifiers-v0.0.1.json"
+            "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/Identifiers-v0.0.1.json"
           }
         },
         "issued": {

--- a/cap/jsonschemas/definitions/MonteCarloSignalDataset-v0.0.1.json
+++ b/cap/jsonschemas/definitions/MonteCarloSignalDataset-v0.0.1.json
@@ -35,7 +35,7 @@
           "description": "",
           "type": "array",
           "items": {
-            "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/Identifiers-v0.0.1.json"
+            "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/Identifiers-v0.0.1.json"
           }
         },
         "issued": {

--- a/cap/jsonschemas/definitions/PrimaryDataset-v0.0.1.json
+++ b/cap/jsonschemas/definitions/PrimaryDataset-v0.0.1.json
@@ -35,7 +35,7 @@
           "description": "",
           "type": "array",
           "items": {
-            "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/Identifiers-v0.0.1.json"
+            "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/Identifiers-v0.0.1.json"
           }
         },
         "issued": {

--- a/cap/jsonschemas/definitions/Publication-v0.0.1.json
+++ b/cap/jsonschemas/definitions/Publication-v0.0.1.json
@@ -8,7 +8,7 @@
       "title": "Identifiers",
       "type": "array",
       "items": {
-        "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/Identifiers-v0.0.1.json"
+        "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/Identifiers-v0.0.1.json"
       }
     },
     "journal_title": {

--- a/cap/jsonschemas/definitions/workflow_schemas/packtivity/packtivity-schema-v0.0.1.json
+++ b/cap/jsonschemas/definitions/workflow_schemas/packtivity/packtivity-schema-v0.0.1.json
@@ -9,31 +9,31 @@
           "type": "object",
           "title": "Process",
           "oneOf":[
-            {"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/process/stringinterp-schema-v0.0.1.json#"},
-            {"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/process/scriptproc-schema-v0.0.1.json#"},
-            {"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/process/manual-instructions-proc-schema-v0.0.1.json#"}
+            {"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/process/stringinterp-schema-v0.0.1.json#"},
+            {"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/process/scriptproc-schema-v0.0.1.json#"},
+            {"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/process/manual-instructions-proc-schema-v0.0.1.json#"}
           ]
       },
       "publisher": {
           "type": "object",
           "title": "Publisher",
           "oneOf":[
-            {"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/publisher/constant-pub-schema-v0.0.1.json#"},
-            {"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/publisher/frompar-pub-schema-v0.0.1.json#"},
-            {"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/publisher/fromyaml-pub-schema-v0.0.1.json#"},
-            {"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/publisher/fromglob-pub-schema-v0.0.1.json#"},
-            {"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/publisher/interpolated-pub-schema-v0.0.1.json#"},
-            {"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/publisher/manual-instructions-pub-schema-v0.0.1.json#"}
+            {"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/publisher/constant-pub-schema-v0.0.1.json#"},
+            {"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/publisher/frompar-pub-schema-v0.0.1.json#"},
+            {"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/publisher/fromyaml-pub-schema-v0.0.1.json#"},
+            {"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/publisher/fromglob-pub-schema-v0.0.1.json#"},
+            {"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/publisher/interpolated-pub-schema-v0.0.1.json#"},
+            {"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/publisher/manual-instructions-pub-schema-v0.0.1.json#"}
           ]
       },
       "environment": {
           "type": "object",
           "title": "Enviroment",
           "oneOf":[
-            {"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/environment/noop-env-schema-v0.0.1.json#"},
-            {"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/environment/localproc-schema-v0.0.1.json#"},
-            {"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/environment/docker-enc-schema-v0.0.1.json#"},
-            {"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/environment/manual-instructions-env-schema-v0.0.1.json#"}
+            {"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/environment/noop-env-schema-v0.0.1.json#"},
+            {"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/environment/localproc-schema-v0.0.1.json#"},
+            {"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/environment/docker-enc-schema-v0.0.1.json#"},
+            {"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/environment/manual-instructions-env-schema-v0.0.1.json#"}
           ]
       }
   },

--- a/cap/jsonschemas/definitions/workflow_schemas/packtivity/publisher/constant-pub-schema-v0.0.1.json
+++ b/cap/jsonschemas/definitions/workflow_schemas/packtivity/publisher/constant-pub-schema-v0.0.1.json
@@ -15,7 +15,7 @@
     "publish": {
       "type": "object",
       "oneOf":[
-        {"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/utils/shallow-primitive-schema-v0.0.1.json#"}
+        {"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/utils/shallow-primitive-schema-v0.0.1.json#"}
       ]
     }
   },

--- a/cap/jsonschemas/definitions/workflow_schemas/yadage/scheduler/multistep-stage-schema-v0.0.1.json
+++ b/cap/jsonschemas/definitions/workflow_schemas/yadage/scheduler/multistep-stage-schema-v0.0.1.json
@@ -12,9 +12,9 @@
       ],
       "default": "multistep-stage"
     },
-    "parameters": { "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/scheduler/parameterselection-v0.0.1.json#" },
-    "step": { "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/packtivity-schema-v0.0.1.json#" },
-    "workflow": {"$ref":"https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/workflow-schema-v0.0.1.json#"},
+    "parameters": { "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/scheduler/parameterselection-v0.0.1.json#" },
+    "step": { "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/packtivity-schema-v0.0.1.json#" },
+    "workflow": {"$ref":"https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/workflow-schema-v0.0.1.json#"},
     "scatter": {
       "type":"object",
       "title": "Scatter",

--- a/cap/jsonschemas/definitions/workflow_schemas/yadage/scheduler/multistep-stage-schema_no_circ_refs-v0.0.1.json
+++ b/cap/jsonschemas/definitions/workflow_schemas/yadage/scheduler/multistep-stage-schema_no_circ_refs-v0.0.1.json
@@ -12,8 +12,8 @@
       ],
       "default": "multistep-stage"
     },
-    "parameters": { "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/scheduler/parameterselection-v0.0.1.json#" },
-    "step": { "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/packtivity-schema-v0.0.1.json#" },
+    "parameters": { "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/scheduler/parameterselection-v0.0.1.json#" },
+    "step": { "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/packtivity-schema-v0.0.1.json#" },
     "workflow": {
       "type": "object"
     },

--- a/cap/jsonschemas/definitions/workflow_schemas/yadage/scheduler/singlestep-stage-schema-v0.0.1.json
+++ b/cap/jsonschemas/definitions/workflow_schemas/yadage/scheduler/singlestep-stage-schema-v0.0.1.json
@@ -10,9 +10,9 @@
       "enum": ["singlestep-stage"],
       "default": "singlestep-stage"
     },
-    "parameters": { "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/scheduler/parameterselection-v0.0.1.json#" },
-    "step": { "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/packtivity-schema-v0.0.1.json#" },
-    "workflow": {"$ref":"https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/workflow-schema-v0.0.1.json#"}
+    "parameters": { "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/scheduler/parameterselection-v0.0.1.json#" },
+    "step": { "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/packtivity-schema-v0.0.1.json#" },
+    "workflow": {"$ref":"https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/workflow-schema-v0.0.1.json#"}
   },
   "required": [
     "scheduler_type"

--- a/cap/jsonschemas/definitions/workflow_schemas/yadage/scheduler/singlestep-stage-schema_no_circ_refs-v0.0.1.json
+++ b/cap/jsonschemas/definitions/workflow_schemas/yadage/scheduler/singlestep-stage-schema_no_circ_refs-v0.0.1.json
@@ -10,8 +10,8 @@
       "enum": ["singlestep-stage"],
       "default": "singlestep-stage"
     },
-    "parameters": { "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/scheduler/parameterselection-v0.0.1.json#" },
-    "step": { "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/packtivity-schema-v0.0.1.json#" },
+    "parameters": { "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/scheduler/parameterselection-v0.0.1.json#" },
+    "step": { "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/packtivity/packtivity-schema-v0.0.1.json#" },
     "workflow": {
       "type": "object"
     }

--- a/cap/jsonschemas/definitions/workflow_schemas/yadage/stage-schema-v0.0.1.json
+++ b/cap/jsonschemas/definitions/workflow_schemas/yadage/stage-schema-v0.0.1.json
@@ -13,15 +13,15 @@
       "type": "object",
       "title": "Dependencies",
       "oneOf": [
-        {"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/predicates/jsonpathready-schema-v0.0.1.json#"}
+        {"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/predicates/jsonpathready-schema-v0.0.1.json#"}
       ]
     },
     "scheduler": {
       "type": "object",
       "title": "Scheduler",
       "oneOf":[
-        {"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/scheduler/singlestep-stage-schema-v0.0.1.json#"},
-        {"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/scheduler/multistep-stage-schema-v0.0.1.json#"}
+        {"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/scheduler/singlestep-stage-schema-v0.0.1.json#"},
+        {"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/scheduler/multistep-stage-schema-v0.0.1.json#"}
       ]
     }
   },

--- a/cap/jsonschemas/definitions/workflow_schemas/yadage/stage-schema_no_circ_refs-v0.0.1.json
+++ b/cap/jsonschemas/definitions/workflow_schemas/yadage/stage-schema_no_circ_refs-v0.0.1.json
@@ -13,15 +13,15 @@
       "type": "object",
       "title": "Dependencies",
       "oneOf": [
-        {"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/predicates/jsonpathready-schema-v0.0.1.json#"}
+        {"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/predicates/jsonpathready-schema-v0.0.1.json#"}
       ]
     },
     "scheduler": {
       "type": "object",
       "title": "Scheduler",
       "oneOf":[
-        {"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/scheduler/singlestep-stage-schema_no_circ_refs-v0.0.1.json#"},
-        {"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/scheduler/multistep-stage-schema_no_circ_refs-v0.0.1.json#"}
+        {"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/scheduler/singlestep-stage-schema_no_circ_refs-v0.0.1.json#"},
+        {"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/scheduler/multistep-stage-schema_no_circ_refs-v0.0.1.json#"}
       ]
     }
   },

--- a/cap/jsonschemas/definitions/workflow_schemas/yadage/workflow-schema-v0.0.1.json
+++ b/cap/jsonschemas/definitions/workflow_schemas/yadage/workflow-schema-v0.0.1.json
@@ -9,7 +9,7 @@
       "type": "array",
       "title": "Stages",
       "items": {
-        "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/stage-schema-v0.0.1.json#"
+        "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/stage-schema-v0.0.1.json#"
       }
     }
   },

--- a/cap/jsonschemas/definitions/workflow_schemas/yadage/workflow-schema_no_circ_refs-v0.0.1.json
+++ b/cap/jsonschemas/definitions/workflow_schemas/yadage/workflow-schema_no_circ_refs-v0.0.1.json
@@ -9,7 +9,7 @@
       "type": "array",
       "title": "Stages",
       "items": {
-        "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/stage-schema_no_circ_refs-v0.0.1.json#"
+        "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/workflow_schemas/yadage/stage-schema_no_circ_refs-v0.0.1.json#"
       }
     }
   }

--- a/cap/jsonschemas/deposits/records/ATLASWorkflows_no_circ_refs-v0.0.1.json
+++ b/cap/jsonschemas/deposits/records/ATLASWorkflows_no_circ_refs-v0.0.1.json
@@ -15,7 +15,7 @@
             }
         },
         "workflows": {
-            "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/ATLASWorkflows_no_circ_refs-v0.0.1.json"
+            "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/ATLASWorkflows_no_circ_refs-v0.0.1.json"
         }
     }
 }

--- a/cap/jsonschemas/deposits/records/atlas-analysis-v1.0.0.json
+++ b/cap/jsonschemas/deposits/records/atlas-analysis-v1.0.0.json
@@ -128,11 +128,11 @@
       "additionalProperties": false,
       "default": [{}],
       "items": {
-        "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/ATLASDataset-v0.0.1.json"
+        "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/ATLASDataset-v0.0.1.json"
       }
     },
-    "workflows": { 
-      "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/ATLASWorkflows_no_circ_refs-v0.0.1.json" 
+    "workflows": {
+      "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/ATLASWorkflows_no_circ_refs-v0.0.1.json"
     },
     "publications": {
       "title": "Publications",
@@ -142,7 +142,7 @@
       "additionalProperties": false,
       "default": [{}],
       "items": {
-        "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/ATLASPublication-v0.0.1.json"
+        "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/ATLASPublication-v0.0.1.json"
       }
     }
   }

--- a/cap/jsonschemas/deposits/records/atlas-workflows-v0.0.1.json
+++ b/cap/jsonschemas/deposits/records/atlas-workflows-v0.0.1.json
@@ -4,13 +4,13 @@
     "type": "object",
     "allOf": [
         {
-            "$ref": "https://analysis-preservation.cern.ch/app/schemas/deposits/common/deposit-v1.0.0.json"
+            "$ref": "https://analysispreservation.cern.ch/app/schemas/deposits/common/deposit-v1.0.0.json"
         },
         {
-            "$ref": "https://analysis-preservation.cern.ch/app/schemas/deposits/records/ATLASWorkflows_no_circ_refs-v0.0.1.json"
+            "$ref": "https://analysispreservation.cern.ch/app/schemas/deposits/records/ATLASWorkflows_no_circ_refs-v0.0.1.json"
         },
         {
-            "$ref": "https://analysis-preservation.cern.ch/app/schemas/deposits/common/file-v1.0.0.json"
+            "$ref": "https://analysispreservation.cern.ch/app/schemas/deposits/common/file-v1.0.0.json"
         }
     ]
 }

--- a/cap/jsonschemas/deposits/records/cms-analysis-v1.0.0-src.json
+++ b/cap/jsonschemas/deposits/records/cms-analysis-v1.0.0-src.json
@@ -4,13 +4,13 @@
     "type": "object",
     "allOf": [
         {
-            "$ref": "https://analysis-preservation.cern.ch/app/schemas/deposits/common/deposit-v1.0.0.json"
+            "$ref": "https://analysispreservation.cern.ch/app/schemas/deposits/common/deposit-v1.0.0.json"
         },
         {
-            "$ref": "https://analysis-preservation.cern.ch/app/schemas/records/cms-analysis-v1.0.0.json"
+            "$ref": "https://analysispreservation.cern.ch/app/schemas/records/cms-analysis-v1.0.0.json"
         },
         {
-            "$ref": "https://analysis-preservation.cern.ch/app/schemas/deposits/common/file-v1.0.0.json"
+            "$ref": "https://analysispreservation.cern.ch/app/schemas/deposits/common/file-v1.0.0.json"
         }
     ]
 }

--- a/cap/jsonschemas/deposits/records/lhcb-v1.0.0-src.json
+++ b/cap/jsonschemas/deposits/records/lhcb-v1.0.0-src.json
@@ -4,13 +4,13 @@
     "type": "object",
     "allOf": [
         {
-            "$ref": "https://analysis-preservation.cern.ch/app/schemas/deposits/common/deposit-v1.0.0.json"
+            "$ref": "https://analysispreservation.cern.ch/app/schemas/deposits/common/deposit-v1.0.0.json"
         },
         {
-            "$ref": "https://analysis-preservation.cern.ch/app/schemas/records/lhcb-v1.0.0.json"
+            "$ref": "https://analysispreservation.cern.ch/app/schemas/records/lhcb-v1.0.0.json"
         },
         {
-            "$ref": "https://analysis-preservation.cern.ch/app/schemas/deposits/common/file-v1.0.0.json"
+            "$ref": "https://analysispreservation.cern.ch/app/schemas/deposits/common/file-v1.0.0.json"
         }
     ]
 }

--- a/cap/jsonschemas/options/definitions/ATLASWorkflows-v0.0.1.json
+++ b/cap/jsonschemas/options/definitions/ATLASWorkflows-v0.0.1.json
@@ -26,7 +26,7 @@
             "key": "workflows[].workflow",
             "condition": "model['workflows'][arrayIndices[0]]['selectSubschema'] == 0",
             "type": "fieldset",
-            "items": {"$ref": "https://analysis-preservation.cern.ch/app/schemas/options/definitions/workflow_schemas/yadage/workflow-schema-v0.0.1.json"}
+            "items": {"$ref": "https://analysispreservation.cern.ch/app/schemas/options/definitions/workflow_schemas/yadage/workflow-schema-v0.0.1.json"}
         }
     ]
 }

--- a/cap/jsonschemas/options/definitions/workflow_schemas/packtivity/packtivity-schema-v0.0.1.json
+++ b/cap/jsonschemas/options/definitions/workflow_schemas/packtivity/packtivity-schema-v0.0.1.json
@@ -21,7 +21,7 @@
         {
             "key": "workflows[].workflow.stages[].scheduler.step.process",
             "condition": "model['workflows'][arrayIndices[0]]['workflow']['stages'][arrayIndices[1]]['scheduler']['step']['process_type'] == 0",
-            "items": {"$ref": "https://analysis-preservation.cern.ch/app/schemas/options/definitions/workflow_schemas/packtivity/process/stringinterp-schema-v0.0.1.json"}
+            "items": {"$ref": "https://analysispreservation.cern.ch/app/schemas/options/definitions/workflow_schemas/packtivity/process/stringinterp-schema-v0.0.1.json"}
         },
         {
             "key": "workflows[].workflow.stages[].scheduler.step.publisher.publisher_type",
@@ -54,22 +54,22 @@
         {
             "key": "workflows[].workflow.stages[].scheduler.step.publisher",
             "condition": "model['workflows'][arrayIndices[0]]['workflow']['stages'][arrayIndices[1]]['scheduler']['step']['publisher']['publisher_type'] == 'constant-pub'",
-            "items": {"$ref": "https://analysis-preservation.cern.ch/app/schemas/options/definitions/workflow_schemas/packtivity/publisher/constant-pub-schema-v0.0.1.json"}
+            "items": {"$ref": "https://analysispreservation.cern.ch/app/schemas/options/definitions/workflow_schemas/packtivity/publisher/constant-pub-schema-v0.0.1.json"}
         },
         {
             "key": "workflows[].workflow.stages[].scheduler.step.publisher",
             "condition": "model['workflows'][arrayIndices[0]]['workflow']['stages'][arrayIndices[1]]['scheduler']['step']['publisher']['publisher_type'] == 'frompar-pub'",
-            "items": {"$ref": "https://analysis-preservation.cern.ch/app/schemas/options/definitions/workflow_schemas/packtivity/publisher/frompar-pub-schema-v0.0.1.json"}
+            "items": {"$ref": "https://analysispreservation.cern.ch/app/schemas/options/definitions/workflow_schemas/packtivity/publisher/frompar-pub-schema-v0.0.1.json"}
         },
         {
             "key": "workflows[].workflow.stages[].scheduler.step.publisher",
             "condition": "model['workflows'][arrayIndices[0]]['workflow']['stages'][arrayIndices[1]]['scheduler']['step']['publisher']['publisher_type'] == 'fromyaml-pub'",
-            "items": {"$ref": "https://analysis-preservation.cern.ch/app/schemas/options/definitions/workflow_schemas/packtivity/publisher/fromyaml-pub-schema-v0.0.1.json"}
+            "items": {"$ref": "https://analysispreservation.cern.ch/app/schemas/options/definitions/workflow_schemas/packtivity/publisher/fromyaml-pub-schema-v0.0.1.json"}
         },
         {
             "key": "workflows[].workflow.stages[].scheduler.step.publisher",
             "condition": "model['workflows'][arrayIndices[0]]['workflow']['stages'][arrayIndices[1]]['scheduler']['step']['publisher']['publisher_type'] == 'fromglob-pub'",
-            "items": {"$ref": "https://analysis-preservation.cern.ch/app/schemas/options/definitions/workflow_schemas/packtivity/publisher/fromglob-pub-schema-v0.0.1.json"}
+            "items": {"$ref": "https://analysispreservation.cern.ch/app/schemas/options/definitions/workflow_schemas/packtivity/publisher/fromglob-pub-schema-v0.0.1.json"}
         }
     ]
 }

--- a/cap/jsonschemas/options/definitions/workflow_schemas/yadage/scheduler/multistep-stage-schema-v0.0.1.json
+++ b/cap/jsonschemas/options/definitions/workflow_schemas/yadage/scheduler/multistep-stage-schema-v0.0.1.json
@@ -1,6 +1,6 @@
 [
-    {"$ref": "https://analysis-preservation.cern.ch/app/schemas/options/definitions/workflow_schemas/yadage/scheduler/parameterselection-v0.0.1.json"},
-    {"$ref": "https://analysis-preservation.cern.ch/app/schemas/options/definitions/workflow_schemas/packtivity/packtivity-schema-v0.0.1.json"},
+    {"$ref": "https://analysispreservation.cern.ch/app/schemas/options/definitions/workflow_schemas/yadage/scheduler/parameterselection-v0.0.1.json"},
+    {"$ref": "https://analysispreservation.cern.ch/app/schemas/options/definitions/workflow_schemas/packtivity/packtivity-schema-v0.0.1.json"},
     {
         "key": "workflows[].workflow.stages[].scheduler.scatter",
         "type": "fieldset",

--- a/cap/jsonschemas/options/definitions/workflow_schemas/yadage/scheduler/singlestep-stage-schema-v0.0.1.json
+++ b/cap/jsonschemas/options/definitions/workflow_schemas/yadage/scheduler/singlestep-stage-schema-v0.0.1.json
@@ -1,4 +1,4 @@
 [
-    {"$ref": "https://analysis-preservation.cern.ch/app/schemas/options/definitions/workflow_schemas/yadage/scheduler/parameterselection-v0.0.1.json"},
-    {"$ref": "https://analysis-preservation.cern.ch/app/schemas/options/definitions/workflow_schemas/packtivity/packtivity-schema-v0.0.1.json"}
+    {"$ref": "https://analysispreservation.cern.ch/app/schemas/options/definitions/workflow_schemas/yadage/scheduler/parameterselection-v0.0.1.json"},
+    {"$ref": "https://analysispreservation.cern.ch/app/schemas/options/definitions/workflow_schemas/packtivity/packtivity-schema-v0.0.1.json"}
 ]

--- a/cap/jsonschemas/options/definitions/workflow_schemas/yadage/stage-schema-v0.0.1.json
+++ b/cap/jsonschemas/options/definitions/workflow_schemas/yadage/stage-schema-v0.0.1.json
@@ -23,7 +23,7 @@
         "key": "workflows[].workflow.stages[].dependencies",
         "condition": "model['workflows'][arrayIndices[0]]['workflow']['stages'][arrayIndices[1]]['dependencies']['dependency_type'] == 'jsonpath_ready'",
         "type": "fieldset",
-        "items": {"$ref": "https://analysis-preservation.cern.ch/app/schemas/options/definitions/workflow_schemas/yadage/predicates/jsonpathready-schema-v0.0.1.json"}
+        "items": {"$ref": "https://analysispreservation.cern.ch/app/schemas/options/definitions/workflow_schemas/yadage/predicates/jsonpathready-schema-v0.0.1.json"}
     },
     {
         "key": "workflows[].workflow.stages[].scheduler.scheduler_type",
@@ -49,7 +49,7 @@
         "key": "workflows[].workflow.stages[].scheduler",
         "condition": "model['workflows'][arrayIndices[0]]['workflow']['stages'][arrayIndices[1]]['scheduler']['scheduler_type'] == 'singlestep-stage'",
         "type": "fieldset",
-        "items": {"$ref": "https://analysis-preservation.cern.ch/app/schemas/options/definitions/workflow_schemas/yadage/scheduler/singlestep-stage-schema-v0.0.1.json"}
+        "items": {"$ref": "https://analysispreservation.cern.ch/app/schemas/options/definitions/workflow_schemas/yadage/scheduler/singlestep-stage-schema-v0.0.1.json"}
     },
     {
         "key": "workflows[].workflow.stages[].scheduler",

--- a/cap/jsonschemas/options/definitions/workflow_schemas/yadage/workflow-schema-v0.0.1.json
+++ b/cap/jsonschemas/options/definitions/workflow_schemas/yadage/workflow-schema-v0.0.1.json
@@ -3,6 +3,6 @@
         "key": "workflows[].workflow.stages",
         "title": "Stages",
         "type": "tabarray",
-        "items": {"$ref": "https://analysis-preservation.cern.ch/app/schemas/options/definitions/workflow_schemas/yadage/stage-schema-v0.0.1.json"}
+        "items": {"$ref": "https://analysispreservation.cern.ch/app/schemas/options/definitions/workflow_schemas/yadage/stage-schema-v0.0.1.json"}
     }
 ]

--- a/cap/jsonschemas/options/deposits/records/atlas-analysis-v1.0.0.json
+++ b/cap/jsonschemas/options/deposits/records/atlas-analysis-v1.0.0.json
@@ -54,7 +54,7 @@
       ]
     },
     {
-      "$ref": "https://analysis-preservation.cern.ch/app/schemas/options/definitions/ATLASWorkflows-v0.0.1.json"
+      "$ref": "https://analysispreservation.cern.ch/app/schemas/options/definitions/ATLASWorkflows-v0.0.1.json"
     },
     {
       "key": "publications",
@@ -92,6 +92,6 @@
           "key": "publications[].comment",
           "placeholder": "E.g. internal draft, support document, etc."
         }
-      ]   
+      ]
     }
 ]

--- a/cap/jsonschemas/options/deposits/records/atlas-workflows-v0.0.1.json
+++ b/cap/jsonschemas/options/deposits/records/atlas-workflows-v0.0.1.json
@@ -2,5 +2,5 @@
     {
         "key": "basic_info"
     },
-    {"$ref": "https://analysis-preservation.cern.ch/app/schemas/options/definitions/ATLASWorkflows-v0.0.1.json"}
+    {"$ref": "https://analysispreservation.cern.ch/app/schemas/options/definitions/ATLASWorkflows-v0.0.1.json"}
 ]

--- a/cap/jsonschemas/records/CMSAnalysis-v0.0.1.json
+++ b/cap/jsonschemas/records/CMSAnalysis-v0.0.1.json
@@ -89,7 +89,7 @@
           "type": "array",
           "id": "primary-datasets",
           "items": {
-            "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/PrimaryDataset-v0.0.1.json",
+            "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/PrimaryDataset-v0.0.1.json",
             "properties": {
               "copypaste": {
                 "type": "string"
@@ -103,7 +103,7 @@
           "type": "array",
           "id": "mc_sig_dataset",
           "items": {
-            "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/MonteCarloSignalDataset-v0.0.1.json",
+            "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/MonteCarloSignalDataset-v0.0.1.json",
             "defaultProperties": [
               "title"
             ]
@@ -115,7 +115,7 @@
           "type": "array",
           "id": "mc_bg_dataset",
           "items": {
-            "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/MonteCarloBackgroundDataset-v0.0.1.json",
+            "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/MonteCarloBackgroundDataset-v0.0.1.json",
             "defaultProperties": [
               "title"
             ]
@@ -141,10 +141,10 @@
         "type": "object",
         "properties": {
           "code_base": {
-            "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/CMSUserCode-v0.0.1.json"
+            "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/CMSUserCode-v0.0.1.json"
           },
           "n_tuple": {
-            "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/CMSInputCodeOutput-v0.0.1.json"
+            "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/CMSInputCodeOutput-v0.0.1.json"
           }
         }
       }
@@ -156,7 +156,7 @@
       "id": "main-measurements",
       "default": [{}],
       "items": {
-        "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/CMSMainMeasurements-v0.0.1.json"
+        "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/CMSMainMeasurements-v0.0.1.json"
       }
     },
     "auxiliary_measurements": {
@@ -165,7 +165,7 @@
       "type": "array",
       "id": "auxiliary-measurements",
       "items": {
-        "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/CMSAuxiliaryMeasurements-v0.0.1.json"
+        "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/CMSAuxiliaryMeasurements-v0.0.1.json"
       }
     },
     "post_n_tuple": {
@@ -174,10 +174,10 @@
       "type": "object",
       "properties": {
         "code_base": {
-          "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/CMSUserCode-v0.0.1.json"
+          "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/CMSUserCode-v0.0.1.json"
         },
         "n_tuple": {
-          "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/CMSFinalInputCodeOutput-v0.0.1.json"
+          "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/CMSFinalInputCodeOutput-v0.0.1.json"
         }
       }
     },
@@ -188,7 +188,7 @@
       "id": "documentations",
       "default": [{}],
       "items": {
-        "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/Documentation-v0.0.1.json"
+        "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/Documentation-v0.0.1.json"
       }
     },
     "internal_discussions": {
@@ -198,7 +198,7 @@
       "id": "internal-discussions",
       "default": [{}],
       "items": {
-        "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/InternalDiscussion-v0.0.1.json"
+        "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/InternalDiscussion-v0.0.1.json"
       }
     },
     "presentations": {
@@ -208,7 +208,7 @@
       "id": "presentations",
       "default": [{}],
       "items": {
-        "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/Presentation-v0.0.1.json"
+        "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/Presentation-v0.0.1.json"
       }
     },
     "publications": {
@@ -218,7 +218,7 @@
       "id": "publications",
       "default": [{}],
       "items": {
-        "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/Publication-v0.0.1.json"
+        "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/Publication-v0.0.1.json"
       }
     },
     "keywords": {

--- a/cap/jsonschemas/records/LHCbAnalysis-v0.0.1.json
+++ b/cap/jsonschemas/records/LHCbAnalysis-v0.0.1.json
@@ -1,5 +1,5 @@
 {
-  "id": "https://analysis-preservation.cern.ch/records/jsonschemas/options/LHCbAnalysis/",
+  "id": "https://analysispreservation.cern.ch/records/jsonschemas/options/LHCbAnalysis/",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "LHCb Analysis Example (JSON Schema)",
   "description": "Schema example for records Schema example for records Schema example for records Schema example for recordsSchema example for recordsSchema example for records",
@@ -370,8 +370,8 @@
         }
       }
     },
-    "workflows": { 
-      "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/LHCbWorkflows.json#" 
+    "workflows": {
+      "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/LHCbWorkflows.json#"
     },
     "documentations": {
       "title": "Documentations",

--- a/cap/jsonschemas/records/atlas-analysis-v1.0.0.json
+++ b/cap/jsonschemas/records/atlas-analysis-v1.0.0.json
@@ -52,11 +52,11 @@
       "additionalProperties": false,
       "default": [{}],
       "items": {
-        "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/ATLASDataset-v0.0.1.json"
+        "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/ATLASDataset-v0.0.1.json"
       }
     },
-    "workflows": { 
-      "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/ATLASWorkflows-v0.0.1.json" 
+    "workflows": {
+      "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/ATLASWorkflows-v0.0.1.json"
     },
     "publications": {
       "title": "Publications",
@@ -66,7 +66,7 @@
       "additionalProperties": false,
       "default": [{}],
       "items": {
-        "$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/ATLASPublication-v0.0.1.json"
+        "$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/ATLASPublication-v0.0.1.json"
       }
     }
   }

--- a/cap/jsonschemas/records/atlas-workflows-v0.0.1.json
+++ b/cap/jsonschemas/records/atlas-workflows-v0.0.1.json
@@ -15,7 +15,7 @@
 			}
 		},
 		"workflows": {
-			"$ref": "https://analysis-preservation.cern.ch/app/schemas/definitions/ATLASWorkflows-v0.0.1.json"
+			"$ref": "https://analysispreservation.cern.ch/app/schemas/definitions/ATLASWorkflows-v0.0.1.json"
 		}
 	},
 	"required": [

--- a/cap/modules/records/resolvers/cap.py
+++ b/cap/modules/records/resolvers/cap.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of CERN Analysis Preservation Framework.
-# Copyright (C) 2016 CERN.
+# Copyright (C) 2016, 2017 CERN.
 #
 # CERN Analysis Preservation Framework is free software; you can redistribute
 # it and/or modify it under the terms of the GNU General Public License as
@@ -36,7 +36,7 @@ import simplejson as json
 from cap.config import JSONSCHEMAS_HOST
 
 @jsonresolver.route('/app/schemas/<path:path>',
-                    host='analysis-preservation.cern.ch')
+                    host='analysispreservation.cern.ch')
 def resolve_cap_schemas(path):
     """Resolve CAP JSON schemas."""
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -18,7 +18,7 @@ Second, clone the repository (or your own fork) if you have not done so already:
 
 .. code-block:: console
 
-    git clone https://github.com/cernanalysispreservation/analysis-preservation.cern.ch.git cap
+    git clone https://github.com/cernanalysispreservation/analysispreservation.cern.ch.git cap
 
 Third, create the virtual environment:
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,7 +96,7 @@ html_theme_options = {
     'logo': 'cap_logo_docs_lrg.svg',
     'description': 'CERN Analysis Preservation is a data preservation service run at CERN currently targeted at storing the LHC experiment data.',
     'github_user': 'cernanalysispreservation',
-    'github_repo': 'analysis-preservation.cern.ch',
+    'github_repo': 'analysispreservation.cern.ch',
     'github_banner': 'banner.svg',
     'github_button': False,
     'sidebar_includehidden': False,
@@ -171,6 +171,3 @@ texinfo_documents = [
      author, 'CERNAnalysisPreservation', 'One line description of project.',
      'Miscellaneous'),
 ]
-
-
-

--- a/scripts/schemas.py
+++ b/scripts/schemas.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # This file is part of CERN Analysis Preservation Framework.
-# Copyright (C) 2016 CERN.
+# Copyright (C) 2016, 2017 CERN.
 #
 # CERN Analysis Preservation Framework is free software; you can redistribute
 # it and/or modify it under the terms of the GNU General Public License as
@@ -42,7 +42,7 @@ print(PROJECT_BASE)
 print(JSONSCHEMAS_DIR)
 print("-----------------------")
 
-BASE_URL = "https://analysis-preservation.cern.ch"
+BASE_URL = "https://analysispreservation.cern.ch"
 UPDATETO_URL = "https://localhost:5000"
 
 


### PR DESCRIPTION
* Amends `analysis-preservation.cern.ch` to read `analysispreservation.cern.ch`
  as the new canonical address.

Signed-off-by: Tibor Simko <tibor.simko@cern.ch>