### PR TITLE
docker: demo user/roles to init script

### DIFF
--- a/cap/modules/access/templates/access/login_user.html
+++ b/cap/modules/access/templates/access/login_user.html
@@ -35,4 +35,16 @@
       </a>
     {% endfor %}
   {% endif %}
+  {% if config.DEBUG %}
+  <hr>
+  {%- with form = login_user_form %}
+  <form action="{{ url_for_security('login') }}" method="POST" name="login_user_form">
+  {{form.hidden_tag()}}
+  {{form_errors(form)}}
+  {{ render_field(form.email, icon="fa fa-user", autofocus=True, errormsg=False) }}
+  {{ render_field(form.password, icon="fa fa-lock", errormsg=False) }}
+    <button type="submit" class="btn btn-primary btn-lg btn-block"><i class="fa fa-sign-in"></i> {{_('Log In')}}</button>
+  </form>
+  {%- endwith %}
+  {% endif %}
 {% endblock %}

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -31,6 +31,26 @@ cap db create
 # Create default user:
 cap users create info@inveniosoftware.org -a --password infoinfo
 
+cap users create cms@cap.ch -a --password cmscms
+cap users create lhcb@cap.ch -a --password lhcblhcb
+cap users create atlas@cap.ch -a --password atlasatlas
+cap users create alice@cap.ch -a --password alicealice
+
+cap roles create cms-members@cern.ch
+cap roles create alice-member@cern.ch
+cap roles create atlas-active-members-all@cern.ch
+cap roles create lhcb-general@cern.ch
+
+cap roles add info@inveniosoftware.org cms-members@cern.ch
+cap roles add info@inveniosoftware.org alice-member@cern.ch
+cap roles add info@inveniosoftware.org atlas-active-members-all@cern.ch
+cap roles add info@inveniosoftware.org lhcb-general@cern.ch
+
+cap roles add cms@cap.ch cms-members@cern.ch
+cap roles add alice@cap.ch alice-member@cern.ch
+cap roles add atlas@cap.ch atlas-active-members-all@cern.ch
+cap roles add lhcb@cap.ch lhcb-general@cern.ch
+
 # Create indexes:
 cap index init
 


### PR DESCRIPTION
Adds demo users and roles to ```init.py``` script. 

Needs ```DEBUG=True```  to display user/pass login form at ```/app/login```

Signed-off-by: Pamfilos Fokianos <pamfilosf@gmail.com>