### PR TITLE
docker: enable debugging with pdb

### DIFF
--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -40,11 +40,13 @@ services:
       - elasticsearch
       - redis
       - wdb
-    command: gunicorn -b 0.0.0.0:5000 --log-level debug  cap.wsgi:application --reload
+    command: gunicorn -b 0.0.0.0:5000 --log-level debug  cap.wsgi:application --reload --timeout 3600
     volumes:
       - ".:/code"
     ports:
       - "5000:5000"
+    stdin_open: true
+    tty: true
 
   # Application Worker
   worker:


### PR DESCRIPTION
* put breakpoints in your code
* use the command ```docker attach CONTAINER_ID``` to attach to the container from your terminal
* debug
* to exit use ```CONTROL + P, CONTROL + Q``` - this will detach from container without killing it (```CONTROL + C``` will stop the container)

Signed-off-by: Anna Trzcinska <anna.trzcinska@cern.ch>