### PR TITLE
travis: pins distro to 'trusty'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ notifications:
 
 sudo: false
 
+dist: trusty
+
 language: python
 
 python:


### PR DESCRIPTION
* after Travis CI uses as default Ubuntu 'xenial'

* https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment

Signed-off-by: Pamfilos Fokianos <pamfilosf@gmail.com>