### PR TITLE
CMS: give write access to harvested cadi entries to cms admin egroup

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 source = cap
-omit = 
+omit =
        *__init__.py
        *ext.py
        *bundles.py
@@ -15,4 +15,5 @@ omit =
        cap/modules/cache/proxies.py
        cap/modules/records/serializers/schemas/json.py
        cap/modules/search_ui/views.py
+       cap/modules/repoimporter/git_importer.py
        ui/*


### PR DESCRIPTION
Signed-off-by: Anna Trzcinska <anna.trzcinska@cern.ch>