### PR TITLE
deposit: remove underscore prefixed fields from requests data

### DIFF
--- a/cap/modules/deposit/loaders.py
+++ b/cap/modules/deposit/loaders.py
@@ -21,173 +21,10 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
-
-
 """CAP Deposit loaders."""
 
 from flask import request
-# from itertools import groupby
-# from operator import attrgetter
-
-# import requests
-# from celery import shared_task
-# from flask import after_this_request, current_app, request
-# from werkzeug.utils import cached_property
-
-# import jsonpointer
-# from cap.modules.deposit.api import CAPDeposit
 from cap.modules.deposit.utils import clean_empty_values
-# from invenio_db import db
-# from invenio_files_rest.models import FileInstance, ObjectVersion
-# from jsonschema.exceptions import ValidationError
-# from jsonschema.validators import Draft4Validator, extend
-
-
-# class XCapFileValidationError(ValidationError):
-#     """Handle x-cap-file schema property."""
-
-#     # @cached_property
-#     # def condition(self):
-#     #     """Return condition value."""
-#     #     return jsonpointer.resolve_pointer(
-#     #         # TODO get default value from schema
-#     #         self.instance, self.validator_value['condition'], True
-#     #     )
-
-#     @cached_property
-#     def url(self):
-#         """Return condition value."""
-#         return jsonpointer.resolve_pointer(
-#             self.instance, self.validator_value['fetch_from'], None
-#         )
-
-#     @cached_property
-#     def file_key(self):
-#         """Return condition value."""
-#         return jsonpointer.resolve_pointer(
-#             self.instance, self.validator_value['file_key'], None
-#         )
-
-#     @cached_property
-#     def ref(self):
-#         """Return JSON pointer to the original source."""
-#         return jsonpointer.JsonPointer.from_parts(self.path).path
-
-#     def update_file_key(self, key):
-#         """Update file key if condition is valid."""
-#         # if self.condition:
-#         jsonpointer.set_pointer(
-#             self.instance, self.validator_value['file_key'], key)
-#         # else:
-#         #     data, part = jsonpointer.JsonPointer(
-#         #         self.validator_value['file_key']
-#         #     ).to_last(
-#         #         self.instance
-#         #     )
-#         #     if data:
-#         #         if part is not None and part in data:
-#         #             del data[part]
-#         #         else:
-#         #             del data
-
-
-# def x_cap_file(validator, config, instance, schema):
-#     """Extract file field configurations."""
-#     yield XCapFileValidationError('Found X-Cap-File')
-
-
-# XCapFileDraft4Validator = extend(Draft4Validator, validators={
-#     'x-cap-file': x_cap_file,
-# })
-
-
-# def extract_refs_from_errors(errors):
-#     """Return list with extracted references from errors."""
-#     return [error.ref for error in errors]
-
-
-# def extract_x_cap_files(data):
-#     """Extract urls and references from data."""
-#     schema = data.get('$schema', None)
-
-#     if not schema:
-#         return []
-
-#     if not isinstance(schema, dict):
-#         schema = {'$ref': schema}
-
-#     resolver = current_app.extensions[
-#         'invenio-records'].ref_resolver_cls.from_schema(schema)
-
-#     return [error for error in XCapFileDraft4Validator(
-#         schema, resolver=resolver
-#     ).iter_errors(data) if isinstance(error, XCapFileValidationError)]
-
-
-# @shared_task(max_retries=2)
-# def download_url(record_id, url):
-#     """Create new file object and assign it to object version."""
-#     record = CAPDeposit.get_record(record_id)
-#     if url.startswith("root://"):
-#         from xrootdpyfs.xrdfile import XRootDPyFile
-#         response = XRootDPyFile(url, mode='r-')
-#         total = response.size
-#     else:
-#         try:
-#             from cap.modules.repoimporter.repo_importer import RepoImporter
-#             link = RepoImporter.create(url).archive_repository()
-#             response = requests.get(link, stream=True).raw
-#             total = int(response.headers.get('Content-Length'))
-#         except TypeError as exc:
-#             download_url.retry(exc=exc)
-#     record.files[url].file.set_contents(
-#         response,
-#         default_location=record.files.bucket.location.uri,
-#         size=total
-#     )
-#     db.session.commit()
-
-
-# def process_x_cap_files(record, x_cap_files):
-#     """Process files, update record."""
-#     result = []
-#     old_keys = set(record.files.keys)
-#     used_keys = set()
-
-#     # Download new files.
-#     urls = {error.url for error in x_cap_files if error.url}
-#     for url in urls:
-#         if url not in record.files:
-#             result.append(url)
-
-#             obj = ObjectVersion.create(
-#                 bucket=record.files.bucket, key=url
-#             )
-#             obj.file = FileInstance.create()
-#             record.files.flush()
-
-#             record.files[url]['source_url'] = url
-
-#     # Update file key for external URLs.
-#     for error in x_cap_files:
-#         if error.url:
-#             error.update_file_key(error.url)
-
-#     # Calculate references.
-#     keyfunc = attrgetter('file_key')
-#     for key, errors in groupby(sorted(x_cap_files, key=keyfunc), keyfunc):
-#         if key is None:
-#             continue
-
-#         refs = extract_refs_from_errors(errors)
-#         if refs:
-#             used_keys.add(key)
-#             record.files[key]['refs'] = refs
-
-#     for key in old_keys - used_keys:
-#         record.files[key]['refs'] = []
-
-#     return result
 
 
 def json_v1_loader(data=None):
@@ -195,19 +32,9 @@ def json_v1_loader(data=None):
     from copy import deepcopy
     data = deepcopy(data or request.json)
 
-    if request and request.view_args.get('pid_value'):
-        _, record = request.view_args.get('pid_value').data
-    #     record_id = str(record.id)
-    #     x_cap_files = extract_x_cap_files(data)
-    #     urls = process_x_cap_files(record, x_cap_files)
-        data['_files'] = record.files.dumps()
-        for file in data['_files']:
-            file['file_name'] = file['key'].split('/')[-1]
+    # remove underscore prefixed fields
+    data = {k: v for k, v in data.items() if not k.startswith('_')}
 
-    #     @after_this_request
-    #     def _preserve_files(response):
-    #         for url in urls:
-    #             download_url.delay(record_id, url)c
-    #         return response
     result = clean_empty_values(data)
+
     return result

--- a/tests/integration/test_create_deposit.py
+++ b/tests/integration/test_create_deposit.py
@@ -43,129 +43,113 @@ def test_create_deposit_when_user_not_logged_in_returns_403(app, users):
         assert resp.status_code == 401
 
 
-def test_create_deposit_when_user_is_member_of_schema_experiment_can_create_deposit(app,
-                                                                                    users,
-                                                                                    location,
-                                                                                    json_headers,
-                                                                                    jsonschemas_host,
-                                                                                    auth_headers_for_user,
-                                                                                    create_schema):
+def test_create_deposit_when_user_is_member_of_schema_experiment_can_create_deposit(
+        app, users, location, json_headers, jsonschemas_host,
+        auth_headers_for_user, create_schema):
     user = users['cms_user']
     other_user = users['lhcb_user']
-    schema = create_schema('deposits/records/cms-v0.0.0',
-                           experiment='CMS')
+    schema = create_schema('deposits/records/cms-v0.0.0', experiment='CMS')
     metadata = {
-        '$schema': 'https://{}/schemas/deposits/records/cms-v0.0.0.json'.format(
-            jsonschemas_host),
+        '$schema':
+            'https://{}/schemas/deposits/records/cms-v0.0.0.json'.format(
+                jsonschemas_host),
     }
     with app.test_client() as client:
-        resp = client.post('/deposits/', data=json.dumps(metadata),
+        resp = client.post('/deposits/',
+                           data=json.dumps(metadata),
                            headers=auth_headers_for_user(user) + json_headers)
 
         assert resp.status_code == 201
 
-        resp = client.post('/deposits/', data=json.dumps(metadata),
-                           headers=auth_headers_for_user(other_user) + json_headers)
+        resp = client.post('/deposits/',
+                           data=json.dumps(metadata),
+                           headers=auth_headers_for_user(other_user) +
+                           json_headers)
 
         assert resp.status_code == 403
 
 
-def test_create_deposit_when_user_is_member_of_egroup_that_has_read_access_to_schema_can_create_deposit(app,
-                                                                                                        users,
-                                                                                                        location,
-                                                                                                        json_headers,
-                                                                                                        jsonschemas_host,
-                                                                                                        auth_headers_for_user,
-                                                                                                        create_schema):
+def test_create_deposit_when_user_is_member_of_egroup_that_has_read_access_to_schema_can_create_deposit(
+        app, users, location, json_headers, jsonschemas_host,
+        auth_headers_for_user, create_schema):
     user = users['lhcb_user']
-    schema = create_schema('deposits/records/cms-v0.0.0',
-                           experiment='LHCb')
+    schema = create_schema('deposits/records/cms-v0.0.0', experiment='LHCb')
     metadata = {
-        '$schema': 'https://{}/schemas/deposits/records/cms-v0.0.0.json'.format(
-            jsonschemas_host),
+        '$schema':
+            'https://{}/schemas/deposits/records/cms-v0.0.0.json'.format(
+                jsonschemas_host),
     }
     with app.test_client() as client:
-        resp = client.post('/deposits/', data=json.dumps(metadata),
+        resp = client.post('/deposits/',
+                           data=json.dumps(metadata),
                            headers=auth_headers_for_user(user) + json_headers)
 
         assert resp.status_code == 201
 
 
-def test_create_deposit_when_user_has_no_permission_to_schema_returns_403(app,
-                                                                          users,
-                                                                          json_headers,
-                                                                          location,
-                                                                          jsonschemas_host,
-                                                                          auth_headers_for_user,
-                                                                          create_schema):
+def test_create_deposit_when_user_has_no_permission_to_schema_returns_403(
+        app, users, json_headers, location, jsonschemas_host,
+        auth_headers_for_user, create_schema):
     user = users['cms_user']
-    schema = create_schema('deposits/records/test-v1.0.1',
-                           experiment='ALICE')
+    schema = create_schema('deposits/records/test-v1.0.1', experiment='ALICE')
     metadata = {
-        '$schema': 'https://{}/schemas/deposits/records/test-v1.0.1.json'.format(
-            jsonschemas_host),
+        '$schema':
+            'https://{}/schemas/deposits/records/test-v1.0.1.json'.format(
+                jsonschemas_host),
     }
 
     with app.test_client() as client:
-        resp = client.post('/deposits/', data=json.dumps(metadata),
+        resp = client.post('/deposits/',
+                           data=json.dumps(metadata),
                            headers=auth_headers_for_user(user) + json_headers)
 
         assert resp.status_code == 403
 
 
-def test_create_deposit_when_superuser_can_create_deposit(app,
-                                                          location,
-                                                          create_schema,
-                                                          jsonschemas_host,
-                                                          auth_headers_for_superuser,
-                                                          json_headers):
+def test_create_deposit_when_superuser_can_create_deposit(
+        app, location, create_schema, jsonschemas_host,
+        auth_headers_for_superuser, json_headers):
     schema = create_schema('deposits/records/test-analysis-v1.0.0')
     metadata = {
-        '$schema': 'https://{}/schemas/deposits/records/test-analysis-v1.0.0.json'.format(
-            jsonschemas_host),
+        '$schema':
+            'https://{}/schemas/deposits/records/test-analysis-v1.0.0.json'.
+            format(jsonschemas_host),
     }
 
     with app.test_client() as client:
-        resp = client.post('/deposits/', headers=auth_headers_for_superuser + json_headers,
+        resp = client.post('/deposits/',
+                           headers=auth_headers_for_superuser + json_headers,
                            data=json.dumps(metadata))
 
         assert resp.status_code == 201
 
 
-def test_create_deposit_when_passed_non_existing_schema_returns_404(app,
-                                                                    location,
-                                                                    create_schema,
-                                                                    jsonschemas_host,
-                                                                    auth_headers_for_superuser,
-                                                                    json_headers):
+def test_create_deposit_when_passed_non_existing_schema_returns_404(
+        app, location, create_schema, jsonschemas_host,
+        auth_headers_for_superuser, json_headers):
     schema = 'https://{}/schemas/non-existing-schema-v1.0.0.json'.format(
         jsonschemas_host)
-    metadata = {
-        '$schema': schema
-    }
+    metadata = {'$schema': schema}
 
     with app.test_client() as client:
-        resp = client.post('/deposits/', headers=auth_headers_for_superuser + json_headers,
+        resp = client.post('/deposits/',
+                           headers=auth_headers_for_superuser + json_headers,
                            data=json.dumps(metadata))
 
         assert resp.status_code == 400
         assert resp.json['message'] == 'Schema {} doesnt exist.'.format(schema)
 
 
-def test_create_deposit_when_passed_non_existing_ana_type_returns_400(app,
-                                                                      location,
-                                                                      create_schema,
-                                                                      jsonschemas_host,
-                                                                      auth_headers_for_superuser,
-                                                                      json_headers):
+def test_create_deposit_when_passed_non_existing_ana_type_returns_400(
+        app, location, create_schema, jsonschemas_host,
+        auth_headers_for_superuser, json_headers):
     ana_type = 'cms-analysis'
 
-    metadata = {
-        '$ana_type': ana_type
-    }
+    metadata = {'$ana_type': ana_type}
 
     with app.test_client() as client:
-        resp = client.post('/deposits/', headers=auth_headers_for_superuser + json_headers,
+        resp = client.post('/deposits/',
+                           headers=auth_headers_for_superuser + json_headers,
                            data=json.dumps(metadata))
 
         assert resp.status_code == 400
@@ -173,14 +157,12 @@ def test_create_deposit_when_passed_non_existing_ana_type_returns_400(app,
             'message'] == 'Schema with name {} doesnt exist.'.format(ana_type)
 
 
-def test_create_deposit_when_passed_empty_data_returns_400(app,
-                                                           location,
-                                                           create_schema,
-                                                           jsonschemas_host,
-                                                           auth_headers_for_superuser,
-                                                           json_headers):
+def test_create_deposit_when_passed_empty_data_returns_400(
+        app, location, create_schema, jsonschemas_host,
+        auth_headers_for_superuser, json_headers):
     with app.test_client() as client:
-        resp = client.post('/deposits/', headers=auth_headers_for_superuser + json_headers,
+        resp = client.post('/deposits/',
+                           headers=auth_headers_for_superuser + json_headers,
                            data=json.dumps({}))
 
         assert resp.status_code == 400
@@ -188,12 +170,9 @@ def test_create_deposit_when_passed_empty_data_returns_400(app,
             'message'] == "You have to specify either $schema or $ana_type"
 
 
-def test_create_deposit_when_passed_ana_type_creates_deposit_with_latest_version_of_ana_type(app,
-                                                                                             location,
-                                                                                             create_schema,
-                                                                                             jsonschemas_host,
-                                                                                             auth_headers_for_superuser,
-                                                                                             json_headers):
+def test_create_deposit_when_passed_ana_type_creates_deposit_with_latest_version_of_ana_type(
+        app, location, create_schema, jsonschemas_host,
+        auth_headers_for_superuser, json_headers):
     create_schema('deposits/records/test-analysis-v1.0.0')
     latest = create_schema('deposits/records/test-analysis-v2.0.0')
     metadata = {'$ana_type': 'test-analysis'}
@@ -207,23 +186,51 @@ def test_create_deposit_when_passed_ana_type_creates_deposit_with_latest_version
         assert resp.json['metadata']['$schema'] == latest.fullpath
 
 
-def test_create_deposit_set_fields_correctly(app,
-                                             location,
-                                             users,
-                                             create_schema,
-                                             jsonschemas_host,
+def test_create_deposit_clears_fields_prefixed_with_underscores(
+        app, location, users, create_schema, jsonschemas_host,
+        auth_headers_for_user, json_headers):
+    owner = users['cms_user']
+    schema = create_schema('deposits/records/test-analysis-v1.0.0',
+                           experiment='CMS')
+    metadata = {
+        '$schema':
+            'https://{}/schemas/deposits/records/test-analysis-v1.0.0.json'.
+            format(jsonschemas_host),
+        '_deposit': 'some-invalid-data',
+        '_experiment': 'some-invalid-data'
+    }
+
+    with app.test_client() as client:
+        resp = client.post('/deposits/',
+                           headers=auth_headers_for_user(owner) + json_headers,
+                           data=json.dumps(metadata))
+
+        assert resp.status_code == 201
+
+        created = resp.json['metadata']
+
+        assert created['_deposit']['created_by'] == owner.id
+        assert created['_deposit']['status'] == 'draft'
+        assert created['$schema'] == schema.fullpath
+        assert created['_experiment'] == 'CMS'
+
+
+def test_create_deposit_set_fields_correctly(app, location, users,
+                                             create_schema, jsonschemas_host,
                                              auth_headers_for_user,
                                              json_headers):
     owner = users['cms_user']
     schema = create_schema('deposits/records/test-analysis-v1.0.0',
                            experiment='CMS')
     metadata = {
-        '$schema': 'https://{}/schemas/deposits/records/test-analysis-v1.0.0.json'.format(
-            jsonschemas_host)
+        '$schema':
+            'https://{}/schemas/deposits/records/test-analysis-v1.0.0.json'.
+            format(jsonschemas_host)
     }
 
     with app.test_client() as client:
-        resp = client.post('/deposits/', headers=auth_headers_for_user(owner) + json_headers,
+        resp = client.post('/deposits/',
+                           headers=auth_headers_for_user(owner) + json_headers,
                            data=json.dumps(metadata))
 
         assert resp.status_code == 201
@@ -236,22 +243,19 @@ def test_create_deposit_set_fields_correctly(app,
         assert created['_deposit']['status'] == 'draft'
 
 
-def test_create_deposit_when_schema_with_refs_works_correctly(app,
-                                                              location,
-                                                              users,
-                                                              create_schema,
-                                                              jsonschemas_host,
-                                                              auth_headers_for_user,
-                                                              json_headers):
+def test_create_deposit_when_schema_with_refs_works_correctly(
+        app, location, users, create_schema, jsonschemas_host,
+        auth_headers_for_user, json_headers):
     owner = users['cms_user']
-    nested_schema = create_schema('nested-schema-v0.0.0', json={
-        'type': 'object',
-        'properties': {
-            'title': {
-                'type': 'string'
-            }
-        }
-    })
+    nested_schema = create_schema('nested-schema-v0.0.0',
+                                  json={
+                                      'type': 'object',
+                                      'properties': {
+                                          'title': {
+                                              'type': 'string'
+                                          }
+                                      }
+                                  })
     nested_schema.add_read_access_to_all()
     schema = create_schema('deposits/records/test-analysis-v1.0.0',
                            experiment='CMS',
@@ -265,7 +269,8 @@ def test_create_deposit_when_schema_with_refs_works_correctly(app,
                            })
 
     with app.test_client() as client:
-        resp = client.post('/deposits/', headers=auth_headers_for_user(owner) + json_headers,
+        resp = client.post('/deposits/',
+                           headers=auth_headers_for_user(owner) + json_headers,
                            data=json.dumps({
                                '$schema': schema.fullpath,
                                'nested': {


### PR DESCRIPTION
* all _ fields are populated by the backend, hence should be ignored in requests
* also removed remainings after x-cap files logic

Signed-off-by: Anna Trzcinska <anna.trzcinska@cern.ch>