### PR TITLE
services: add indico service view prototype

### DIFF
--- a/cap/jsonschemas/definitions/indico-events-v0.0.1.json
+++ b/cap/jsonschemas/definitions/indico-events-v0.0.1.json
@@ -1,0 +1,185 @@
+{
+  "fullname": "Indico Events",
+  "experiment": null,
+  "jsonschema": {
+    "title": "Indico Events",
+    "description": "Events taken from indico.cern.ch",
+    "properties": {
+      "id": {
+        "type": "string",
+        "title": "ID"
+      },
+      "title": {
+        "type": "string",
+        "title": "Title"
+      },
+      "description": {
+        "type": "string",
+        "title": "Description"
+      },
+      "category": {
+        "type": "string",
+        "title": "Category"
+      },
+      "url": {
+        "type": "string",
+        "title": "URL"
+      },
+      "location": {
+        "type": "string",
+        "title": "Location"
+      },
+      "address": {
+        "type": "string",
+        "title": "Address"
+      },
+      "room": {
+        "type": "string",
+        "title": "Room"
+      },
+      "room_map_url": {
+        "type": "string",
+        "title": "Room Map URL"
+      },
+      "creation_date": {
+        "type": "string",
+        "title": "Event creation date"
+      },
+      "start_date": {
+        "type": "string",
+        "title": "Event start date"
+      },
+      "end_date": {
+        "type": "string",
+        "title": "Event end date"
+      },
+
+      "creator": {
+        "type": "object",
+        "properties": {
+          "affiliation": {
+            "type": "string",
+            "title": "Affiliation"
+          },
+          "last_name": {
+            "type": "string",
+            "title": "Last Name"
+          },
+          "first_name": {
+            "type": "string",
+            "title": "First Name"
+          },
+          "full_name": {
+            "type": "string",
+            "title": "Full Name"
+          },
+          "id": {
+            "type": "string",
+            "title": "ID"
+          }
+        }
+      },
+
+      "chairs": {
+        "type": "array",
+        "title": "Chairs",
+        "items": {
+          "type": "object",
+          "properties": {
+            "person_id": {
+              "type": "number",
+              "title": "Person ID"
+            },
+            "id": {
+              "type": "string",
+              "title": "ID"
+            },
+            "affiliation": {
+              "type": "string",
+              "title": "Affiliation"
+            },
+            "last_name": {
+              "type": "string",
+              "title": "Last Name"
+            },
+            "first_name": {
+              "type": "string",
+              "title": "First Name"
+            },
+            "full_name": {
+              "type": "string",
+              "title": "Full Name"
+            }
+          }
+        }
+      },
+
+      "folders": {
+        "type": "array",
+        "title": "Folders",
+        "items": {
+          "type": "object",
+          "properties": {
+            "title": {
+              "type": "string",
+              "title": "Title"
+            },
+            "description": {
+              "type": "string",
+              "title": "Title"
+            },
+            "id": {
+              "type": "string",
+              "title": "ID"
+            },
+            "attachments": {
+              "type": "array",
+              "title": "Attachments",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string",
+                    "title": "Title"
+                  },
+                  "description": {
+                    "type": "string",
+                    "title": "Title"
+                  },
+                  "id": {
+                    "type": "string",
+                    "title": "ID"
+                  },
+                  "content_type": {
+                    "type": "string",
+                    "title": "Content Type"
+                  },
+                  "size": {
+                    "type": "number",
+                    "title": "Size"
+                  },
+                  "modified_dt": {
+                    "type": "string",
+                    "title": "Modified Date"
+                  },
+                  "filename": {
+                    "type": "string",
+                    "title": "File Name"
+                  },
+                  "download_url": {
+                    "type": "string",
+                    "title": "ID"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "type": "object",
+    "id": "indico_events"
+  },
+  "is_deposit": false
+}

--- a/cap/modules/services/serializers/__init__.py
+++ b/cap/modules/services/serializers/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+
+"""CAP services serializer."""
+
+from __future__ import absolute_import, print_function

--- a/cap/modules/services/serializers/indico.py
+++ b/cap/modules/services/serializers/indico.py
@@ -1,0 +1,119 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Analysis Preservation Framework.
+# Copyright (C) 2016 CERN.
+#
+# CERN Analysis Preservation Framework is free software; you can redistribute
+# it and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Analysis Preservation Framework is distributed in the hope that it will
+# be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CERN Analysis Preservation Framework; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+"""Serializers for Reana models."""
+
+from __future__ import absolute_import, print_function
+from datetime import datetime
+import pytz
+
+from marshmallow import Schema, fields
+
+
+class IndicoDateField(fields.Field):
+    """Schema for date extraction."""
+
+    def _serialize(self, val, attr, obj):
+        # add milliseconds to time to ensure the parsing works
+        _time = val['time'] if '.' in val['time'] else val['time'] + '.0'
+        _dateobj = datetime.strptime('{} {}'.format(val['date'], _time),
+                                     '%Y-%m-%d %H:%M:%S.%f')
+
+        _tz = pytz.timezone(val['tz'])
+        return _tz.localize(_dateobj, is_dst=None).isoformat()
+
+
+class IndicoEventSchema(Schema):
+    """Schema for Indico events in JSON."""
+
+    id = fields.Str(dump_only=True)
+    title = fields.Str(dump_only=True)
+    description = fields.Str(dump_only=True)
+    category = fields.Str(dump_only=True)
+    url = fields.Str(dump_only=True)
+    location = fields.Str(dump_only=True)
+    address = fields.Str(dump_only=True)
+    room = fields.Str()
+    room_map_url = fields.Str(attribute='roomFullname', dump_only=True)
+
+    start_date = IndicoDateField(attribute='startDate', dump_only=True)
+    end_date = IndicoDateField(attribute='endDate', dump_only=True)
+    creation_date = IndicoDateField(attribute='creationDate', dump_only=True)
+
+    creator = fields.Method('get_creator', dump_only=True)
+    chairs = fields.Method('get_chairs', dump_only=True)
+    folders = fields.Method('get_folders', dump_only=True)
+
+    def get_creator(self, obj):
+        """Get the serialized creator of the event."""
+        creator = obj['creator']
+        return {
+            'creator_id': creator['id'],
+            'affiliation': creator['affiliation'],
+            'first_name': creator['first_name'],
+            'last_name': creator['last_name'],
+            'full_name': creator['fullName']
+        }
+
+    def get_chairs(self, obj):
+        """Get the serialized chairs of the event."""
+        _chairs = []
+        for chair in obj['chairs']:
+            _chairs.append({
+                'chair_db_id': chair['id'],
+                'person_id': chair['person_id'],
+                'affiliation': chair['affiliation'],
+                'first_name': chair['first_name'],
+                'last_name': chair['last_name'],
+                'full_name': chair['fullName']
+            })
+
+        return _chairs
+
+    def get_folders(self, obj):
+        """Get the serialized folders of the event."""
+        _folders = []
+        for folder in obj['folders']:
+            _folder = {
+                'folder_id': folder['id'],
+                'title': folder['title'],
+                'description': folder['description'],
+            }
+
+            if folder['attachments']:
+                _attachments = []
+                for att in folder['attachments']:
+                    _attachments.append({
+                        'attachment_id': att['id'],
+                        'title': att['title'],
+                        'size': att['size'],
+                        'filename': att['filename'],
+                        'description': att['description'],
+                        'content_type': att['content_type'],
+                        'modified_dt': att['modified_dt'],
+                        'download_url': att['download_url'],
+                    })
+                _folder.update({'attachments': _attachments})
+            _folders.append(_folder)
+
+        return _folders

--- a/cap/modules/services/test_responses/responses.py
+++ b/cap/modules/services/test_responses/responses.py
@@ -197,3 +197,144 @@ atlas_glance = {u'count': 1, u'links': [
 
 github = {}
 gitlab = {u'error': u'404 Not Found'}
+indico = {
+  "count": 1,
+  "additionalInfo": {},
+  "_type": "HTTPAPIResult",
+  "url": "https://indico.cern.ch/export/event/845049.json",
+  "results": [
+    {
+      "folders": [
+        {
+          "_type": "folder",
+          "attachments": [
+            {
+              "_type": "attachment",
+              "description": "",
+              "content_type": "image/png",
+              "id": 3136666,
+              "size": 2294221,
+              "modified_dt": "2019-08-30T14:30:46.031039+00:00",
+              "title": "img_2.png",
+              "download_url": "https://indico.cern.ch/event/845049/attachments/1900364/3136666/img_2.png",
+              "filename": "img_2.png",
+              "is_protected": False,
+              "type": "file"
+            }
+          ],
+          "title": None,
+          "is_protected": False,
+          "default_folder": True,
+          "id": 1900364,
+          "description": ""
+        },
+        {
+          "_type": "folder",
+          "attachments": [],
+          "title": "another folder",
+          "is_protected": False,
+          "default_folder": False,
+          "id": 1900363,
+          "description": "another folder for stuff"
+        },
+        {
+          "_type": "folder",
+          "attachments": [],
+          "title": "materials_folder",
+          "is_protected": False,
+          "default_folder": False,
+          "id": 1900362,
+          "description": "this folder has materials"
+        }
+      ],
+      "startDate": {
+        "date": "2019-08-30",
+        "tz": "Europe/Zurich",
+        "time": "17:00:00"
+      },
+      "_type": "Conference",
+      "hasAnyProtection": False,
+      "endDate": {
+        "date": "2019-08-30",
+        "tz": "Europe/Zurich",
+        "time": "19:00:00"
+      },
+      "description": "<p>this is the description stuff</p>",
+      "roomMapURL": "https://maps.cern.ch/mapsearch/mapsearch.htm?n=['4/2-037']",
+      "creator": {
+        "affiliation": "",
+        "_type": "Avatar",
+        "last_name": "Koutsakis",
+        "emailHash": "514487040d28517d3c94700dd987e10e",
+        "_fossil": "conferenceChairMetadata",
+        "fullName": "Koutsakis, Ilias",
+        "first_name": "Ilias",
+        "id": "77851"
+      },
+      "material": [],
+      "visibility": {
+        "id": "",
+        "name": "Everywhere"
+      },
+      "roomFullname": "4/2-037 - TH meeting room",
+      "references": [
+        {
+          "url": None,
+          "urn": None,
+          "type": "Local",
+          "value": "localID"
+        },
+        {
+          "url": "https://edms.cern.ch/document/edmsID",
+          "urn": None,
+          "type": "EDMS",
+          "value": "edmsID"
+        }
+      ],
+      "address": "Address Adressington 13, Geneva",
+      "timezone": "Europe/Zurich",
+      "creationDate": {
+        "date": "2019-08-30",
+        "tz": "Europe/Zurich",
+        "time": "16:27:13.211866"
+      },
+      "id": "845049",
+      "category": "TEST Category",
+      "room": "4/2-037",
+      "title": "test_folders",
+      "url": "https://indico.cern.ch/event/845049/",
+      "note": {},
+      "chairs": [
+        {
+          "person_id": 4676217,
+          "affiliation": "CERN",
+          "_type": "ConferenceChair",
+          "last_name": "Fokianos",
+          "db_id": 770812,
+          "emailHash": "0bc625725a7099d0e24b738432077ba2",
+          "_fossil": "conferenceChairMetadata",
+          "fullName": "Fokianos, Pamfilos",
+          "first_name": "Pamfilos",
+          "id": "770812"
+        },
+        {
+          "person_id": 4676216,
+          "affiliation": "",
+          "_type": "ConferenceChair",
+          "last_name": "Koutsakis",
+          "db_id": 770811,
+          "emailHash": "514487040d28517d3c94700dd987e10e",
+          "_fossil": "conferenceChairMetadata",
+          "fullName": "Mr Koutsakis, Ilias",
+          "first_name": "Ilias",
+          "id": "770811"
+        }
+      ],
+      "location": "CERN",
+      "_fossil": "conferenceMetadata",
+      "type": "meeting",
+      "categoryId": 2
+    }
+  ],
+  "ts": 1567417389
+}

--- a/cap/modules/services/views/__init__.py
+++ b/cap/modules/services/views/__init__.py
@@ -14,4 +14,4 @@ blueprint = Blueprint('cap_services',
                       url_prefix='/services'
                       )
 
-from . import zenodo, cern, orcid, status_checks  # noqa
+from . import zenodo, cern, orcid, indico, status_checks  # noqa

--- a/cap/modules/services/views/indico.py
+++ b/cap/modules/services/views/indico.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Analysis Preservation Framework.
+# Copyright (C) 2018 CERN.
+#
+# CERN Analysis Preservation Framework is free software; you can redistribute
+# it and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Analysis Preservation Framework is distributed in the hope that it will
+# be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CERN Analysis Preservation Framework; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+
+
+"""CAP Indico service views."""
+
+import requests
+from flask import jsonify
+from urllib3.exceptions import HTTPError
+
+from . import blueprint
+from ..serializers.indico import IndicoEventSchema
+from cap.modules.access.utils import login_required
+from cap.modules.experiments.errors import ExternalAPIException
+
+INDICO_URL = 'https://indico.cern.ch/export/event/{}.json?tz=Europe/Zurich'
+
+
+def _indico(event_id):
+    """Get Indico event by id."""
+    url = INDICO_URL.format(event_id)
+    resp = requests.get(url)
+    return resp.json(), resp.status_code
+
+
+@blueprint.route('/indico/<event_id>')
+@login_required
+def get_indico_event(event_id):
+    """Get Indico event by id and serialize the response."""
+    try:
+        resp, status = _indico(event_id)
+        serialized = IndicoEventSchema().dump(resp['results'][0]).data
+        return jsonify(serialized), status
+    except IndexError:
+        return jsonify([]), 200
+    except ExternalAPIException:
+        raise

--- a/cap/modules/services/views/status_checks.py
+++ b/cap/modules/services/views/status_checks.py
@@ -35,9 +35,10 @@ from . import blueprint
 from .orcid import _get_orcid
 from .zenodo import _get_zenodo_record
 from .cern import _ldap
+from .indico import _indico
 from ..models import StatusCheck
 from ..test_responses.responses import orcid_id, orcid_name, zenodo, \
-    ldap_egroup, ldap_mail, cms_cadi, atlas_glance, github, gitlab
+    ldap_egroup, ldap_mail, cms_cadi, atlas_glance, github, gitlab, indico
 
 from cap.views import ping
 from cap.modules.experiments.views.atlas import _get_glance_by_id
@@ -78,6 +79,12 @@ status_checks = [
         'should_return': ldap_egroup,
         'service': 'ldap_egroup',
         'log': 'Checking CERN LDAP by egroup...'
+    }, {
+        'func': _indico,
+        'args': {'event_id': '845049'},
+        'should_return': indico,
+        'service': 'indico',
+        'log': 'Checking Indico GET by event id...'
     },
 
     # INTERNAL SERVICES

--- a/tests/integration/test_indico_views.py
+++ b/tests/integration/test_indico_views.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Analysis Preservation Framework.
+# Copyright (C) 2017 CERN.
+#
+# CERN Analysis Preservation Framework is free software; you can redistribute
+# it and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Analysis Preservation Framework is distributed in the hope that it will
+# be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CERN Analysis Preservation Framework; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+# or submit itself to any jurisdiction.
+
+"""Integration tests for CAP api."""
+
+from __future__ import absolute_import, print_function
+from mock import patch
+
+from cap.modules.experiments.errors import ExternalAPIException
+
+
+@patch('cap.modules.services.views.indico._indico')
+def test_indico_empty_list(mock_indico, app, auth_headers_for_superuser):
+    mock_indico_id = '1111'
+    mock_indico.return_value = {u'count': 0, u'additionalInfo': {}, u'_type': u'HTTPAPIResult',
+                                u'url': u'https://indico.cern.ch/export/event/1111.json',
+                                u'ts': 1568636014, u'results': []}, 200
+
+    with app.test_client() as client:
+        resp = client.get('services/indico/{}'.format(mock_indico_id), headers=auth_headers_for_superuser)
+
+        assert resp.status_code == 200
+        assert resp.json == []
+
+
+@patch('cap.modules.services.views.indico._indico', side_effect=ExternalAPIException())
+def test_indico_exception(mock_indico, app, auth_headers_for_superuser):
+    mock_indico_id = '848989'
+
+    with app.test_client() as client:
+        resp = client.get('services/indico/{}'.format(mock_indico_id), headers=auth_headers_for_superuser)
+
+        assert resp.status_code == 503
+        assert resp.json['message'] == 'External API replied with an error.'
+
+
+@patch('cap.modules.services.views.indico._indico')
+def test_indico(mock_indico, app, auth_headers_for_superuser):
+    mock_indico_id = '848989'
+    mock_indico.return_value = ({
+        '_type': 'HTTPAPIResult', 'additionalInfo': {}, 'count': 1,
+        'results': [{'_fossil': 'conferenceMetadata', '_type': 'Conference',
+                     'address': '', 'category': 'TEST Category', 'categoryId': 2,
+                     'chairs': [], 'material': [], 'references': [], 'note': {},
+                     'creator': {'_fossil': 'conferenceChairMetadata', '_type': 'Avatar',
+                                 'affiliation': '', 'emailHash': '514487040d28517d3c94700dd987e10e',
+                                 'first_name': 'Ilias', 'fullName': 'Koutsakis, Ilias',
+                                 'id': '77851', 'last_name': 'Koutsakis'},
+                     'description': '', 'room': '', 'roomFullname': '', 'roomMapURL': None, 'title': 'test',
+                     'creationDate': {'date': '2019-09-16', 'time': '13:46:47.701463', 'tz': 'Europe/Zurich'},
+                     'endDate': {'date': '2019-09-16', 'time': '16:00:00', 'tz': 'Europe/Zurich'},
+                     'startDate': {'date': '2019-09-16', 'time': '14:00:00', 'tz': 'Europe/Zurich'},
+                     'folders': [], 'hasAnyProtection': False, 'id': '848989',
+                     'location': 'CERN', 'timezone': 'Europe/Zurich', 'type': 'simple_event',
+                     'url': 'https://indico.cern.ch/event/848989/',
+                     'visibility': {'id': '', 'name': 'Everywhere'}}],
+        'ts': 1568634418, 'url': 'https://indico.cern.ch/export/event/848989.json'}, 200)
+
+    with app.test_client() as client:
+        resp = client.get('services/indico/{}'.format(mock_indico_id), headers=auth_headers_for_superuser)
+
+        assert resp.status_code == 200
+        assert resp.json == {
+            "address": "", "category": "TEST Category", "description": "", "id": "848989",
+            "room_map_url": "", "title": "test", "url": "https://indico.cern.ch/event/848989/",
+            "chairs": [], "folders": [], "location": "CERN", "room": "",
+            "creation_date": "2019-09-16T13:46:47.701463+02:00",
+            "end_date": "2019-09-16T16:00:00+02:00",
+            "start_date": "2019-09-16T14:00:00+02:00",
+            "creator": {"affiliation": "", "creator_id": "77851", "first_name": "Ilias",
+                        "full_name": "Koutsakis, Ilias",
+                        "last_name": "Koutsakis"}
+        }


### PR DESCRIPTION
* closes #1205

Includes implementation of the Indico service endpoint and serializer,
and implementation of the corresponding status check.

Signed-off-by: Ilias Koutsakis <ilias.koutsakis@cern.ch>