### PR TITLE
ui: remove useless firefox scrollbar from legend

### DIFF
--- a/ui/src/index.js
+++ b/ui/src/index.js
@@ -7,10 +7,10 @@ import store, { history } from "./store/configureStore";
 import Root from "./components/Root";
 import { authenticated } from "./actions/auth";
 
+import "grommet/scss/hpinc/index.scss";
+
 import "./styles/styles.scss"; // Yep, that's right. You can import SASS/CSS files too! Webpack will run the associated loader and plug this into the page.
 // require('./favicon.ico'); // Tell webpack to load favicon.ico
-
-import "grommet/scss/hpinc/index.scss";
 
 const user = localStorage.getItem("token");
 

--- a/ui/src/styles/styles.scss
+++ b/ui/src/styles/styles.scss
@@ -30,6 +30,11 @@ body {
   box-sizing: border-box;
 }
 
+// remove scrollbar from the Dashboard circle legend
+.grommetux-legend {
+  overflow: visible;
+}
+
 #app {
   height: 100vh;
   overflow-y: scroll;


### PR DESCRIPTION
Remove the scrollbar from the circle visualization legend.
Browser: Firefox 