### PR TITLE
UI: redirection onreload to undefined fixed

### DIFF
--- a/ui/src/actions/auth.js
+++ b/ui/src/actions/auth.js
@@ -94,7 +94,7 @@ export function loginLocalUser(data) {
   };
 }
 
-export function initCurrentUser(next) {
+export function initCurrentUser(next = undefined) {
   return function(dispatch) {
     axios
       .get("/api/me")
@@ -110,7 +110,10 @@ export function initCurrentUser(next) {
             depositGroups: deposit_groups
           })
         );
-        history.push(`${next}`);
+        // if next is defined
+        if (next) {
+          history.push(next);
+        }
       })
       .catch(function() {
         dispatch(clearAuth());


### PR DESCRIPTION
Update the initCurrentUser(next).

When the next is not defined, it means that we do not want to redirect.

That skips the problem with the redirection on reload to /undefined