### PR TITLE
global: optimize deposits and records serializers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,6 @@ dist: bionic
 language: python
 
 python:
-  - "2.7"
   - "3.6"
 
 services:

--- a/cap/modules/deposit/links.py
+++ b/cap/modules/deposit/links.py
@@ -25,6 +25,8 @@
 
 from __future__ import absolute_import, print_function
 
+from cachetools import LRUCache, cached
+from cachetools.keys import hashkey
 from flask import current_app, request
 from invenio_records_files.links import default_bucket_link_factory
 
@@ -34,7 +36,8 @@ from .api import CAPDeposit
 from .utils import extract_actions_from_class
 
 
-def links_factory(pid, record=None):
+@cached(LRUCache(maxsize=1024), key=lambda pid, **kwargs: hashkey(str(pid)))
+def links_factory(pid, record=None, record_hit=None, **kwargs):
     """Deposit links factory."""
     links = {
         'self': api_url_for('depid_item', pid),

--- a/cap/modules/deposit/serializers/json.py
+++ b/cap/modules/deposit/serializers/json.py
@@ -25,9 +25,10 @@
 
 from __future__ import absolute_import, print_function
 
-from cap.modules.deposit.links import links_factory as deposit_links_factory
 from invenio_pidstore.models import PersistentIdentifier
 from invenio_records_rest.serializers.json import JSONSerializer
+
+from cap.modules.deposit.links import links_factory as deposit_links_factory
 
 
 class DepositSerializer(JSONSerializer):

--- a/cap/modules/deposit/serializers/schemas/json.py
+++ b/cap/modules/deposit/serializers/schemas/json.py
@@ -27,13 +27,12 @@ from __future__ import absolute_import, print_function
 
 import copy
 
-from marshmallow import Schema, fields
+from invenio_jsonschemas import current_jsonschemas
+from marshmallow import fields
 
 from cap.modules.deposit.api import CAPDeposit
-from cap.modules.deposit.permissions import (AdminDepositPermission,
-                                             UpdateDepositPermission)
+from cap.modules.deposit.permissions import UpdateDepositPermission
 from cap.modules.records.serializers.schemas import common
-from invenio_jsonschemas import current_jsonschemas
 
 
 class DepositSchema(common.CommonRecordSchema):
@@ -43,34 +42,26 @@ class DepositSchema(common.CommonRecordSchema):
     recid = fields.Str(attribute='metadata._deposit.pid.value',
                        dump_only=True)  # only for published ones
 
-    can_update = fields.Method('can_user_update', dump_only=True)
-    can_admin = fields.Method('can_user_admin', dump_only=True)
-
     cloned_from = fields.Dict(attribute='metadata._deposit.cloned_from.value',
                               dump_only=True)
-
-    def can_user_update(self, obj):
-        deposit = CAPDeposit.get_record(obj['pid'].object_uuid)
-        return UpdateDepositPermission(deposit).can()
-
-    def can_user_admin(self, obj):
-        deposit = CAPDeposit.get_record(obj['pid'].object_uuid)
-        return AdminDepositPermission(deposit).can()
 
 
 class DepositFormSchema(DepositSchema):
     """Schema for deposit v1 in JSON."""
 
     schemas = fields.Method('get_deposit_schemas', dump_only=True)
+    can_update = fields.Method('can_user_update', dump_only=True)
 
     def get_deposit_schemas(self, obj):
         deposit = CAPDeposit.get_record(obj['pid'].object_uuid)
 
-        schema = current_jsonschemas.get_schema(
-            deposit.schema.deposit_path,
-            with_refs=True,
-            resolved=True
-        )
+        schema = current_jsonschemas.get_schema(deposit.schema.deposit_path,
+                                                with_refs=True,
+                                                resolved=True)
         uiSchema = deposit.schema.deposit_options
 
         return dict(schema=copy.deepcopy(schema), uiSchema=uiSchema)
+
+    def can_user_update(self, obj):
+        deposit = CAPDeposit.get_record(obj['pid'].object_uuid)
+        return UpdateDepositPermission(deposit).can()

--- a/cap/modules/records/links.py
+++ b/cap/modules/records/links.py
@@ -27,13 +27,15 @@ from __future__ import absolute_import, print_function
 
 from flask import current_app, request
 from invenio_records_files.links import default_bucket_link_factory
-from invenio_records_rest.links import default_links_factory
 
-from .api import CAPRecord
+from cachetools import LRUCache, cached
+from cachetools.keys import hashkey
+
 from .utils import api_url_for, url_to_api_url
 
 
-def links_factory(pid, record=None):
+@cached(LRUCache(maxsize=1024), key=lambda pid, **kwargs: hashkey(str(pid)))
+def links_factory(pid, record=None, record_hit=None, **kwargs):
     """Deposit links factory."""
     links = {
         'self': api_url_for('recid_item', pid),

--- a/cap/modules/records/serializers/schemas/common.py
+++ b/cap/modules/records/serializers/schemas/common.py
@@ -28,6 +28,7 @@ from invenio_accounts.models import Role, User
 from marshmallow import Schema, ValidationError, fields, validates_schema
 
 from cap.modules.schemas.resolvers import resolve_schema_by_url
+from cap.modules.user.utils import get_role_name_by_id, get_user_email_by_id
 
 
 class StrictKeysMixin(object):
@@ -89,7 +90,8 @@ class CommonRecordSchema(Schema, StrictKeysMixin):
     def get_metadata(self, obj):
         result = {
             k: v
-            for k, v in obj.get('metadata', {}).items() if k not in [
+            for k, v in obj.get('metadata', {}).items()
+            if k not in [
                 'control_number', '$schema', '_deposit', '_experiment',
                 '_access', '_files'
             ]
@@ -110,11 +112,9 @@ class CommonRecordSchema(Schema, StrictKeysMixin):
         for permission in access.values():
             if permission['users']:
                 for index, user_id in enumerate(permission['users']):
-                    user = User.query.filter_by(id=user_id).one()
-                    permission['users'][index] = user.email
+                    permission['users'][index] = get_user_email_by_id(user_id)
             if permission['roles']:
                 for index, role_id in enumerate(permission['roles']):
-                    role = Role.query.filter_by(id=role_id).one()
-                    permission['roles'][index] = role.name
+                    permission['roles'][index] = get_role_name_by_id(role_id)
 
         return access

--- a/cap/modules/schemas/resolvers.py
+++ b/cap/modules/schemas/resolvers.py
@@ -29,17 +29,14 @@ import re
 
 import jsonresolver
 from flask import abort, current_app, has_request_context
+from sqlalchemy.orm.exc import NoResultFound
+
+from cachetools.func import lru_cache
 from invenio_jsonschemas.errors import JSONSchemaNotFound
 from invenio_jsonschemas.proxies import current_jsonschemas
-from sqlalchemy.orm.exc import NoResultFound
 
 from .models import Schema
 from .permissions import ReadSchemaPermission
-
-try:
-    from functools import lru_cache
-except ImportError:
-    from functools32 import lru_cache
 
 
 @jsonresolver.route('/schemas/<path:path>',

--- a/cap/profilers.py
+++ b/cap/profilers.py
@@ -1,0 +1,30 @@
+import cProfile
+import pstats
+
+
+def calls_profile(func,
+                  subcalls=True,
+                  builtins=False,
+                  sortby='cumulative',
+                  n=20):
+    """Decorator to profile function calls.
+
+    Print to stdout stats from cProfile.
+
+    :param subcalls: count subcalls. (default: True)
+    :param builtins: count builtin functions calls. (default: False)
+    :param sortby: sort by specified column. (default: 'cumulative')
+    :param n: print only n calls. (default: 20)
+    """
+    def profiled_func(*args, **kwargs):
+        profile = cProfile.Profile(builtins=builtins, subcalls=subcalls)
+        try:
+            profile.enable()
+            result = func(*args, **kwargs)
+            profile.disable()
+            return result
+        finally:
+            ps = pstats.Stats(profile).sort_stats(sortby)
+            ps.print_stats(n)
+
+    return profiled_func

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ tests_require = [
     'pytest-pep8>=1.0.6',
     'pytest-random-order>=0.5.4',
     'pytest==3.8.1',
+    'yapf>=0.28.0',
     'responses==0.10.6',
     'selenium>=3.4.3',
 ]

--- a/tests/integration/test_clone_deposits.py
+++ b/tests/integration/test_clone_deposits.py
@@ -158,8 +158,6 @@ def test_deposit_clone_works_correctly(client, users, auth_headers_for_user,
                 'users': [owner.email]
             }
         },
-        'can_update': True,
-        'can_admin': True,
         'links': {
             'bucket':
                 'http://analysispreservation.cern.ch/api/files/{}'.format(

--- a/tests/integration/test_create_deposit.py
+++ b/tests/integration/test_create_deposit.py
@@ -28,12 +28,12 @@ from __future__ import absolute_import, print_function
 
 import json
 
-from invenio_jsonschemas.errors import JSONSchemaNotFound
 from invenio_records.api import RecordMetadata
-from pytest import mark, raises
 
 from cap.modules.deposit.api import CAPDeposit
 from cap.modules.schemas.models import Schema
+from invenio_jsonschemas.errors import JSONSchemaNotFound
+from pytest import mark, raises
 
 
 #######################
@@ -219,8 +219,6 @@ def test_create_deposit_set_fields_correctly(client, location, users,
                 'users': [owner.email]
             }
         },
-        'can_update': True,
-        'can_admin': True,
         'is_owner': True,
         'links': {
             'bucket':

--- a/tests/integration/test_edit_published_deposit.py
+++ b/tests/integration/test_edit_published_deposit.py
@@ -102,8 +102,6 @@ def test_edit_record(client, create_deposit, superuser,
                 'users': [superuser.email]
             }
         },
-        'can_update': True,
-        'can_admin': True,
         'is_owner': True,
         'links': {
             'bucket':

--- a/tests/integration/test_get_deposits.py
+++ b/tests/integration/test_get_deposits.py
@@ -256,8 +256,6 @@ def test_get_deposit_with_default_serializer(client, users,
                 'users': [owner.email]
             }
         },
-        'can_update': True,
-        'can_admin': True,
         'is_owner': True,
         'links': {
             'bucket':

--- a/tests/integration/test_get_records.py
+++ b/tests/integration/test_get_records.py
@@ -168,8 +168,6 @@ def test_get_records_default_serializer(client, superuser,
             'size': file.file.size,
             'version_id': str(file.version_id)
         }],
-        'can_admin': True,
-        'can_update': True,
        'is_owner': True,
         'links': {
             'bucket':
@@ -281,8 +279,6 @@ def test_get_record_when_superuser_returns_record(client, db, users,
             'size': file.file.size,
             'version_id': str(file.version_id)
         }],
-        'can_admin': True,
-        'can_update': True,
        'is_owner': True,
         'links': {
             'bucket':

--- a/tests/integration/test_publish_deposit.py
+++ b/tests/integration/test_publish_deposit.py
@@ -164,8 +164,6 @@ def test_deposit_publish_changes_status_and_creates_record(
                 'users': [owner.email]
             }
         },
-        'can_update': True,
-        'can_admin': True,
         'is_owner': True,
         'links': {
             'bucket':

--- a/tests/integration/test_update_deposit.py
+++ b/tests/integration/test_update_deposit.py
@@ -247,8 +247,6 @@ def test_update_deposit_cannot_update_underscore_prefixed_files(
                 'users': [owner.email]
             }
         },
-        'can_update': True,
-        'can_admin': True,
         'is_owner': True,
         'links': {
             'bucket':
@@ -382,8 +380,6 @@ def test_patch_deposit_cannot_update_underscore_prefixed_fields(
                 'users': [owner.email]
             }
         },
-        'can_update': True,
-        'can_admin': True,
         'is_owner': True,
         'links': {
             'bucket':


### PR DESCRIPTION
* get rid of can_update, can_admin
* use is_owner instead
* cache links factories
* cache user and roles names
* closes #1352

Signed-off-by: Anna Trzcinska <anna.trzcinska@cern.ch>