### PR TITLE
ui: draft preview word break to be responsive

### DIFF
--- a/ui/src/components/drafts/form/themes/grommet-preview/templates/FieldTemplate.js
+++ b/ui/src/components/drafts/form/themes/grommet-preview/templates/FieldTemplate.js
@@ -14,7 +14,7 @@ let FieldTemplate = function(props) {
   return children.props && children.props.formData === undefined ? null : (
     <Box flex={true} direction="row">
       {label ? (
-        <Box>
+        <Box flex={true}>
           <FieldHeader title={label} />
         </Box>
       ) : null}

--- a/ui/src/components/drafts/form/themes/grommet-preview/widgets/TextWidget.js
+++ b/ui/src/components/drafts/form/themes/grommet-preview/widgets/TextWidget.js
@@ -13,9 +13,9 @@ class TextWidget extends React.Component {
   render() {
     return (
       <Box
-        style={{ overflow: "hidden" }}
-        pad={{ horizontal: "medium" }}
+        style={{ overflow: "hidden", wordBreak: "break-all" }}
         size={{ width: "xxlarge" }}
+        pad={{ horizontal: "medium" }}
         justify="center"
         flex={false}
         alignSelf="end"

--- a/ui/src/components/partials/SectionBox.js
+++ b/ui/src/components/partials/SectionBox.js
@@ -31,11 +31,7 @@ function SectionBox(props) {
         <ReactTooltip />
       </Box>
 
-      <Box
-        flex={false}
-        size={{ height: { max: "medium" } }}
-        colorIndex="light-1"
-      >
+      <Box flex={false} size={{ height: { max: "large" } }}>
         {body}
       </Box>
       {more && (


### PR DESCRIPTION
Added CSS rule wordBreak: break-all

![Screenshot 2020-01-22 at 15 44 25](https://user-images.githubusercontent.com/19371945/72903931-645fa080-3d2e-11ea-8bcd-c69fc4078b09.png)

