### PR TITLE
deposits: add _fetched_from and _user_edited fields to schemas and mappings

### DIFF
--- a/cap/config.py
+++ b/cap/config.py
@@ -16,18 +16,6 @@ from os.path import dirname, join
 
 import requests
 from flask import request
-from flask import request
-from jsonresolver import JSONResolver
-from jsonresolver.contrib.jsonref import json_loader_factory
-
-from cap.modules.deposit.permissions import (AdminDepositPermission,
-                                             CreateDepositPermission,
-                                             ReadDepositPermission)
-from cap.modules.oauthclient.contrib.cern import disconnect_handler
-from cap.modules.oauthclient.rest_handlers import (authorized_signup_handler,
-                                                   signup_handler)
-from cap.modules.records.permissions import ReadRecordPermission
-from cap.modules.search.facets import nested_filter, prefix_filter
 from flask_principal import RoleNeed
 from invenio_deposit import config as deposit_config
 from invenio_deposit.config import DEPOSIT_REST_SORT_OPTIONS
@@ -37,6 +25,8 @@ from invenio_oauthclient.contrib.cern import REMOTE_APP as CERN_REMOTE_APP
 from invenio_records_rest.config import RECORDS_REST_ENDPOINTS
 from invenio_records_rest.facets import terms_filter
 from invenio_records_rest.utils import allow_all, deny_all
+from jsonresolver import JSONResolver
+from jsonresolver.contrib.jsonref import json_loader_factory
 
 from cap.modules.deposit.permissions import (AdminDepositPermission,
                                              CreateDepositPermission,
@@ -122,7 +112,7 @@ CELERY_BEAT_SCHEDULE = {
     'ping_webhooks': {
         'task': 'cap.modules.repoimporter.tasks.ping_webhooks',
         'schedule': timedelta(hours=12),
-        },
+    },
     'das_harvester': {
         'task': 'cap.modules.experiments.tasks.cms.harvest_das',
         'schedule': timedelta(days=1),
@@ -165,9 +155,12 @@ SESSION_COOKIE_SECURE = False
 #: should be set to the correct host and it is strongly recommended to only
 #: route correct hosts to the application.
 APP_ALLOWED_HOSTS = [
-    'localhost', 'analysispreservation.web.cern.ch',
-    'analysispreservation.cern.ch', 'analysispreservation-dev.web.cern.ch',
-    'analysispreservation-dev.cern.ch', 'analysispreservation-qa.web.cern.ch',
+    'localhost',
+    'analysispreservation.web.cern.ch',
+    'analysispreservation.cern.ch',
+    'analysispreservation-dev.web.cern.ch',
+    'analysispreservation-dev.cern.ch',
+    'analysispreservation-qa.web.cern.ch',
     'analysispreservation-qa.cern.ch'
 ]
 
@@ -266,11 +259,6 @@ CAP_FACETS = {
                 'field': 'cadi_status'
             }
         },
-        'facet_publication_status': {
-            'terms': {
-                'field': 'publication_status.keyword'
-            }
-        },
         'facet_cms_working_group': {
             'terms': {
                 "script": "doc.containsKey('cadi_id') ? doc['cadi_id'].value?.substring(0,3) : null"  # noqa
@@ -313,9 +301,7 @@ CAP_FACETS = {
     'post_filters': {
         'type': terms_filter('_type'),
         'cms_working_group': prefix_filter('cadi_id'),
-        'publication_status': terms_filter('publication_status.keyword'),
         'cadi_status': terms_filter('cadi_status'),
-        'conference': terms_filter('conference'),
         'physics_objects': nested_filter(
             'main_measurements.signal_event_selection.physics_objects',
             'main_measurements.signal_event_selection'

--- a/cap/modules/deposit/api.py
+++ b/cap/modules/deposit/api.py
@@ -76,6 +76,8 @@ PRESERVE_FIELDS = (
     '_files',
     '_experiment',
     '_access',
+    '_user_edited',
+    '_fetched_from',
     'general_title',
     '$schema',
 )
@@ -137,6 +139,8 @@ class CAPDeposit(Deposit):
             '_deposit',
             '_access',
             '_experiment',
+            '_fetched_from',
+            '_user_edited',
             'general_title',
             '$schema',
         )
@@ -162,6 +166,8 @@ class CAPDeposit(Deposit):
             '/_access',
             '/_files',
             '/_experiment',
+            '/_fetched_from',
+            '/_user_edited',
             '/$schema',
         )
 
@@ -407,6 +413,11 @@ class CAPDeposit(Deposit):
     def commit(self, *args, **kwargs):
         """Synchronize files before commit."""
         self.files.flush()
+
+        # mark as manually edited
+        if current_user:
+            self['_user_edited'] = True
+
         return super(CAPDeposit, self).commit(*args, **kwargs)
 
     def _add_user_permissions(self, user, permissions, session):

--- a/cap/modules/experiments/utils/cadi.py
+++ b/cap/modules/experiments/utils/cadi.py
@@ -62,7 +62,9 @@ def synchronize_cadi_entries(limit=None):
         return {
             '$ana_type': 'cms-analysis',
             'cadi_info': cadi_info,
-            'general_title': cadi_id,
+            'general_title': cadi_info.get('name') or cadi_id,
+            '_fetched_from': 'cadi',
+            '_user_edited': False,
             'basic_info': {
                 'cadi_id': cadi_id
             }
@@ -147,7 +149,7 @@ def get_all_from_cadi():
     # filter out inactive or superseded entries
     entries = [
         entry for entry in all_entries
-        if entry['status'] not in ['Inactive', 'SUPERSEDED']
+        if entry['status'] not in ['Inactive', 'SUPERSEDED', 'Free']
     ]
 
     return entries

--- a/cap/modules/fixtures/schemas/alice-analysis.json
+++ b/cap/modules/fixtures/schemas/alice-analysis.json
@@ -33,6 +33,12 @@
       "_experiment": {
         "type": "string"
       },
+      "_fetched_from": {
+        "type": "string"
+      },
+      "_user_edited": {
+        "type": "boolean"
+      },
       "_access": {
         "$ref":
           "https://analysispreservation.cern.ch/schemas/deposits/records/access-v0.0.1.json"
@@ -77,6 +83,14 @@
         "_experiment": {
           "type": "text"
         },
+        "_fetched_from": {
+          "type": "text",
+          "copy_to": "fetched_from"
+        },
+        "_user_edited": {
+          "type": "boolean",
+          "copy_to": "user_edited"
+        },
         "_created": {
           "type": "date",
           "copy_to": "created"
@@ -92,7 +106,7 @@
     }
   },
   "deposit_options": {
-    "ui:order": ["analysis_title", "train_analysis"],
+    "ui:order": ["analysis_title", "train_analysis", "*"],
     "train_analysis": {
       "items": {
         "ui:order": [

--- a/cap/modules/fixtures/schemas/atlas.json
+++ b/cap/modules/fixtures/schemas/atlas.json
@@ -88,6 +88,12 @@
       "_experiment": {
         "type": "string"
       },
+      "_fetched_from": {
+        "type": "string"
+      },
+      "_user_edited": {
+        "type": "boolean"
+      },
       "_access": {
         "$ref":
           "https://analysispreservation.cern.ch/schemas/deposits/records/access-v0.0.1.json"
@@ -151,6 +157,14 @@
         },
         "_experiment": {
           "type": "text"
+        },
+        "_fetched_from": {
+          "type": "text",
+          "copy_to": "fetched_from"
+        },
+        "_user_edited": {
+          "type": "boolean",
+          "copy_to": "user_edited"
         },
         "_created": {
           "type": "date",

--- a/cap/modules/fixtures/schemas/cms-questionnaire.json
+++ b/cap/modules/fixtures/schemas/cms-questionnaire.json
@@ -658,6 +658,12 @@
       "_experiment": {
         "type": "string"
       },
+      "_fetched_from": {
+        "type": "string"
+      },
+      "_user_edited": {
+        "type": "boolean"
+      },
       "_access": {
         "$ref":
           "https://analysispreservation.cern.ch/schemas/deposits/records/access-v0.0.1.json"

--- a/cap/modules/fixtures/schemas/cms.json
+++ b/cap/modules/fixtures/schemas/cms.json
@@ -387,6 +387,12 @@
       },
       "_experiment": {
         "type": "string"
+      },
+      "_fetched_from": {
+        "type": "string"
+      },
+      "_user_edited": {
+        "type": "boolean"
       }
     }
   },
@@ -413,6 +419,14 @@
         },
         "_experiment": {
           "type": "text"
+        },
+        "_fetched_from": {
+          "type": "text",
+          "copy_to": "fetched_from"
+        },
+        "_user_edited": {
+          "type": "boolean",
+          "copy_to": "user_edited"
         },
         "_created": {
           "type": "date",

--- a/cap/modules/fixtures/schemas/lhcb.json
+++ b/cap/modules/fixtures/schemas/lhcb.json
@@ -1,5 +1,5 @@
 {
-  "name": "lhcb-analysis",
+  "name": "lhcb",
   "version": "0.0.1",
   "fullname": "LHCb Analysis",
   "experiment": "LHCb",
@@ -204,6 +204,12 @@
       "_experiment": {
         "type": "string"
       },
+      "_fetched_from": {
+        "type": "string"
+      },
+      "_user_edited": {
+        "type": "boolean"
+      },
       "_access": {
         "$ref":
           "https://analysispreservation.cern.ch/schemas/deposits/records/access-v0.0.1.json"
@@ -404,6 +410,14 @@
         },
         "_experiment": {
           "type": "text"
+        },
+        "_fetched_from": {
+          "type": "text",
+          "copy_to": "fetched_from"
+        },
+        "_user_edited": {
+          "type": "boolean",
+          "copy_to": "user_edited"
         },
         "_created": {
           "type": "date",

--- a/cap/modules/records/serializers/schemas/common.py
+++ b/cap/modules/records/serializers/schemas/common.py
@@ -39,16 +39,16 @@ LABELS = {
         'path': 'metadata.basic_info.cadi_id',
         'condition': lambda obj: obj['metadata']['_experiment'] == 'CMS'
     },
-    'cms_keywords': {
-        'path': 'metadata.additional_resources.keywords',
-        'condition': lambda obj: obj['metadata']['_experiment'] == 'CMS'
-    },
-    'version': {
-        'path': 'revision',
-        'condition': lambda obj: obj['metadata']['_deposit']['status'] == \
-        'published',
-        'formatter': 'v{}'
-    }
+    #    'cms_keywords': {
+    #        'path': 'metadata.additional_resources.keywords',
+    #        'condition': lambda obj: obj['metadata']['_experiment'] == 'CMS'
+    #    },
+    #    'version': {
+    #        'path': 'revision',
+    #      'condition': lambda obj: obj['metadata']['_deposit']['status'] == \
+    #        'published',
+    #        'formatter': 'v{}'
+    #    }
 }
 
 

--- a/cap/modules/records/serializers/schemas/common.py
+++ b/cap/modules/records/serializers/schemas/common.py
@@ -113,10 +113,17 @@ class CommonRecordSchema(Schema, StrictKeysMixin):
     def get_metadata(self, obj):
         result = {
             k: v
-            for k, v in obj.get('metadata', {}).items()
+            for k,
+            v in obj.get('metadata', {}).items()
             if k not in [
-                'control_number', '$schema', '_deposit', '_experiment',
-                '_access', '_files'
+                'control_number',
+                '$schema',
+                '_deposit',
+                '_experiment',
+                '_access',
+                '_files',
+                '_fetched_from',
+                '_user_edited'
             ]
         }
         return result

--- a/cap/modules/records/serializers/schemas/json.py
+++ b/cap/modules/records/serializers/schemas/json.py
@@ -75,10 +75,17 @@ class BasicDepositSchema(Schema):
     def get_metadata(self, obj):
         result = {
             k: v
-            for k, v in obj.get('metadata', {}).items()
+            for k,
+            v in obj.get('metadata', {}).items()
             if k not in [
-                'control_number', '$schema', '_deposit', '_experiment',
-                '_access', '_files'
+                'control_number',
+                '$schema',
+                '_deposit',
+                '_experiment',
+                '_access',
+                '_files',
+                '_user_edited',
+                '_fetched_from'
             ]
         }
         return result

--- a/tests/integration/test_get_records.py
+++ b/tests/integration/test_get_records.py
@@ -138,7 +138,7 @@ def test_get_records_default_serializer(client, superuser,
         'created_by': superuser.email,
         'created': metadata.created.strftime('%Y-%m-%dT%H:%M:%S.%f+00:00'),
         'updated': metadata.updated.strftime('%Y-%m-%dT%H:%M:%S.%f+00:00'),
-        'labels': ['v0'],
+        'labels': [],
         'access': {
             'record-admin': {
                 'roles': [],
@@ -252,7 +252,7 @@ def test_get_record_when_superuser_returns_record(client, db, users,
         'created_by': owner.email,
         'created': metadata.created.strftime('%Y-%m-%dT%H:%M:%S.%f+00:00'),
         'updated': metadata.updated.strftime('%Y-%m-%dT%H:%M:%S.%f+00:00'),
-        'labels': ['v0'],
+        'labels': [],
         'access': {
             'record-admin': {
                 'roles': [],

--- a/tests/integration/test_publish_deposit.py
+++ b/tests/integration/test_publish_deposit.py
@@ -25,14 +25,11 @@
 """Integration tests for publishing deposits."""
 
 import json
-import re
 
-from flask_principal import ActionNeed
 from invenio_access.models import ActionRoles, ActionUsers
 from pytest import mark
 
 from cap.modules.experiments.permissions import exp_need_factory
-from cap.modules.user.utils import get_existing_or_register_role
 from conftest import _datastore
 
 
@@ -148,7 +145,7 @@ def test_deposit_publish_changes_status_and_creates_record(
         'created_by': owner.email,
         'created': metadata.created.strftime('%Y-%m-%dT%H:%M:%S.%f+00:00'),
         'updated': metadata.updated.strftime('%Y-%m-%dT%H:%M:%S.%f+00:00'),
-        'labels': ['v2'],
+        'labels': [],
         'metadata': {},
         'files': [],
         'access': {

--- a/tests/integration/test_serializers.py
+++ b/tests/integration/test_serializers.py
@@ -167,7 +167,7 @@ def test_default_record_serializer(client, users, auth_headers_for_user,
             'name': 'cms-analysis',
             'version': '1.0.0'
         },
-        'labels': ['v0'],
+        'labels': [],
         'created_by': owner.email,
         'created': metadata.created.strftime('%Y-%m-%dT%H:%M:%S.%f+00:00'),
         'updated': metadata.updated.strftime('%Y-%m-%dT%H:%M:%S.%f+00:00'),

--- a/ui/src/components/dashboard/DashboardQuickSearch.js
+++ b/ui/src/components/dashboard/DashboardQuickSearch.js
@@ -9,19 +9,23 @@ import { TagCloud } from "react-tagcloud";
 import { withRouter } from "react-router";
 
 const data = [
+  {
+    value: "from CADI and edited",
+    count: 3,
+    link: "/drafts?q=fetched_from:cadi user_edited:true"
+  },
+  {
+    value: "from CADI and not edited",
+    count: 3,
+    link: "/drafts?q=fetched_from:cadi NOT user_edited:true"
+  },
   { value: "EXO", count: 3, link: "/search?q=&cms_wg=EXO" },
   { value: "muon", count: 2, link: "/search?q=object:muon" },
   { value: "draft", count: 2, link: "/drafts?q=" },
   { value: "published by me", count: 1, link: "/search?q=&by_me=True" },
   { value: "TOP", count: 3, link: "/search?q=&cms_wg=TOP" },
   { value: "electron", count: 3, link: "/search?q=object:electron" },
-  {
-    value: "from CADI",
-    count: 2,
-    link: "/drafts?q=&type=cms-analysis-v0.0.1&by_bot=True"
-  },
   { value: "QCD", count: 2, link: "/search?q=&cms_wg=QCD" },
-  { value: "CMS", count: 3, link: "/search?q=CMS" },
   { value: "my drafts", count: 1, link: "/drafts?q=&by_me=True" },
   { value: "higgs boson", count: 3, link: "/search?q=higgs boson" },
   { value: "proton-proton", count: 3, link: "/search?q=proton-proton" },
@@ -33,9 +37,6 @@ const data = [
   { value: "vertex", count: 3, link: "/search?q=object:vertex" },
   { value: "T quark pair", count: 2, link: "/search?q=T quark pair" },
   { value: "Z → e+e− decays", count: 1, link: "/search?q=Z → e+e− decays" },
-  { value: "ALICE", count: 3, link: "/search?q=ALICE" },
-  { value: "ATLAS", count: 3, link: "/search?q=ATLAS" },
-  { value: "LHCb", count: 3, link: "/search?q=LHCb" }
 ];
 
 class DashboardQuickSearch extends React.Component {
@@ -72,7 +73,6 @@ class DashboardQuickSearch extends React.Component {
         >
           <TagCloud
             style={{ cursor: "pointer" }}
-            shuffle
             minSize={15}
             maxSize={20}
             tags={data}

--- a/ui/src/components/drafts/DraftEditor.js
+++ b/ui/src/components/drafts/DraftEditor.js
@@ -30,6 +30,8 @@ export const transformSchema = schema => {
     "$schema",
     "general_title",
     "_experiment",
+    "_fetched_from",
+    "_user_edited",
     "control_number"
   ];
 

--- a/ui/src/components/drafts/DraftPreview.js
+++ b/ui/src/components/drafts/DraftPreview.js
@@ -24,6 +24,8 @@ const transformSchema = schema => {
     "$schema",
     "general_title",
     "_experiment",
+    "_fetched_from",
+    "_user_edited",
     "control_number"
   ];
 

--- a/ui/src/components/published/PublishedPreview.js
+++ b/ui/src/components/published/PublishedPreview.js
@@ -28,6 +28,8 @@ const transformSchema = schema => {
     "$schema",
     "general_title",
     "_experiment",
+    "_fetched_from",
+    "_user_edited",
     "control_number"
   ];
 

--- a/ui/src/components/search/SearchResults.js
+++ b/ui/src/components/search/SearchResults.js
@@ -83,9 +83,11 @@ class SearchResults extends React.Component {
                     </Box>
                     <Box direction="row">
                       <ReactTooltip />
+                      {rights &&
                       <Box>
                         <KeywordLabel> {rights} </KeywordLabel>
                       </Box>
+                      }
                       {labels.map(item => {
                         return (
                           <Box>


### PR DESCRIPTION
* add fields to schema to keep track of harvested entries
* once user edited harvested record, set _user_edited flag
* add quick search query for CMS to get all the cadi entries
* closes #1419

Signed-off-by: Anna Trzcinska <anna.trzcinska@cern.ch>