### PR TITLE
cms: index datasets in batches

### DIFF
--- a/cap/modules/experiments/cli.py
+++ b/cap/modules/experiments/cli.py
@@ -56,7 +56,7 @@ def sync_with_cadi_database(limit):
 def index_datasets(file):
     """Load datasets from file and index in ES."""
     with open(file, 'r') as fp:
-        source = json.load(fp)
+        source = (dict(name=line.strip()) for line in fp)
         cache_das_datasets_in_es_from_file(source)
 
     click.secho("Datasets indexed in Elasticsearch.", fg='green')
@@ -66,9 +66,9 @@ def index_datasets(file):
 @click.option('--file', '-f', required=True, type=click.Path(exists=True))
 @with_appcontext
 def index_triggers(file):
-    """Load cms triggers from file and index in ES."""
+    """Load cms triggers from json file and index in ES."""
     with open(file, 'r') as fp:
-        source = json.load(fp)
+        source = (x for x in json.load(fp))
         cache_cms_triggers_in_es_from_file(source)
 
     click.secho("Triggers indexed in Elasticsearch.", fg='green')

--- a/cap/modules/experiments/tasks/cms.py
+++ b/cap/modules/experiments/tasks/cms.py
@@ -108,7 +108,7 @@ def reindex_das_entries():
         current_app.config['EXPERIMENTS_RESOURCES_LOCATION'], 'das.txt')
 
     with open(file_location, 'r') as fp:
-        source = tuple(dict(name=line.strip()) for line in fp)
+        source = (dict(name=line.strip()) for line in fp)
         cache_das_datasets_in_es_from_file(source)
 
     current_app.logger.info('DAS entries indexed succesfully.')

--- a/cap/modules/experiments/utils/common.py
+++ b/cap/modules/experiments/utils/common.py
@@ -24,6 +24,7 @@
 """Experiments common utils."""
 
 from functools import wraps
+from itertools import count, groupby
 from os.path import join
 from subprocess import CalledProcessError, check_output
 
@@ -90,7 +91,11 @@ def generate_krb_cookie(principal, kt, url):
     return generate(url)
 
 
-def recreate_es_index_from_source(alias, source, mapping=None, settings=None):
+def recreate_es_index_from_source(alias,
+                                  source,
+                                  mapping=None,
+                                  settings=None,
+                                  id_getter=None):
     """
     Recreate index in ES, with documents passed in source.
 
@@ -104,6 +109,11 @@ def recreate_es_index_from_source(alias, source, mapping=None, settings=None):
     :param dict mapping: ES Mapping object
     :param dict settings: ES Settings object
     """
+    def _batches(iterable, chunk_size=10):
+        c = count()
+        for _, g in groupby(iterable, lambda _: next(c) // chunk_size):
+            yield g
+
     if es.indices.exists('{}-v1'.format(alias)):
         old_index, new_index = ('{}-v1'.format(alias), '{}-v2'.format(alias))
     else:
@@ -115,21 +125,22 @@ def recreate_es_index_from_source(alias, source, mapping=None, settings=None):
     es.indices.create(index=new_index,
                       body=dict(mappings=mapping, settings=settings or {}))
 
-    # index datasets from file under new index
-    try:
-        print("Indexing...")
-        actions = [{
-            "_index": new_index,
-            "_type": 'doc',
-            "_id": idx,
-            "_source": obj
-        } for idx, obj in enumerate(source)]
+    print("Indexing...", end='', flush=True)
 
-        helpers.bulk(es, actions)
-    except Exception as e:
-        # delete index if sth went wrong
-        es.indices.delete(index=new_index)
-        raise e
+    for batch in _batches(source, chunk_size=50000):
+        try:
+            actions = [{
+                '_id': id_getter(obj) if id_getter else None,
+                '_source': obj
+            } for obj in batch]
+            helpers.bulk(es, actions, index=new_index, doc_type='doc')
+            print('.', end='', flush=True)
+        except Exception as e:
+            es.indices.delete(
+                index=old_index)  # delete index if sth went wrong
+            raise e
+
+    print('')
 
     # add newly created index under das-datasets alias
     es.indices.put_alias(index=new_index, name=alias)

--- a/cap/modules/experiments/utils/das.py
+++ b/cap/modules/experiments/utils/das.py
@@ -40,7 +40,8 @@ def update_term_for_das_query(term):
 
 def cache_das_datasets_in_es_from_file(source):
     """Cache datasets names from DAS in ES."""
-    recreate_es_index_from_source(alias=DAS_DATASETS_ES_CONFIG['alias'],
+    recreate_es_index_from_source(source=source,
+                                  alias=DAS_DATASETS_ES_CONFIG['alias'],
                                   mapping=DAS_DATASETS_ES_CONFIG['mappings'],
                                   settings=DAS_DATASETS_ES_CONFIG['settings'],
-                                  source=source)
+                                  id_getter=lambda obj: obj['name'])

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,6 @@ decorator==4.3.0          # via ipython, traitlets, validators
 dojson==1.4.0             # via invenio-oaiserver
 elasticsearch-dsl==5.4.0  # via invenio-search
 elasticsearch==5.5.2      # via elasticsearch-dsl, invenio-search
-enum34==1.1.6             # via cryptography, invenio-pidstore, traitlets
 flask-admin==1.5.1        # via invenio-accounts, invenio-admin
 flask-alembic==2.0.1      # via invenio-db
 flask-assets==0.12        # via invenio-assets


### PR DESCRIPTION
* don't load in memory the whole set of datasets
* harvest das from all instances done in #1434
* closes #1422

Signed-off-by: Anna Trzcinska <anna.trzcinska@cern.ch>