### PR TITLE
ui:  add report links to the preview

### DIFF
--- a/ui/src/components/drafts/DraftEditor.js
+++ b/ui/src/components/drafts/DraftEditor.js
@@ -96,9 +96,11 @@ class DraftEditor extends React.Component {
         {this.props.schemas &&
           this.props.schemas.schema && (
             <Box flex={true}>
-              <Box flex={false} separator="bottom" style={{ padding: "5px" }}>
-                <DraftEditorHeader formRef={this.props.formRef} />
-              </Box>
+              {this.props.canUpdate && (
+                <Box flex={false} separator="bottom" style={{ padding: "5px" }}>
+                  <DraftEditorHeader formRef={this.props.formRef} />
+                </Box>
+              )}
               <Box
                 direction="row"
                 justify="between"
@@ -139,7 +141,8 @@ DraftEditor.propTypes = {
   fetchAndAssignSchema: PropTypes.func,
   fetchSchemaByNameVersion: PropTypes.func,
   formRef: PropTypes.object,
-  errors: PropTypes.oneOfType([PropTypes.object, PropTypes.array])
+  errors: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
+  canUpdate: PropTypes.bool
 };
 
 function mapStateToProps(state) {
@@ -152,7 +155,8 @@ function mapStateToProps(state) {
     metadata: state.draftItem.get("metadata"),
     formData: state.draftItem.get("formData"),
     errors: state.draftItem.get("errors"),
-    schemaErrors: state.draftItem.get("schemaErrors")
+    schemaErrors: state.draftItem.get("schemaErrors"),
+    canUpdate: state.draftItem.get("can_update")
   };
 }
 

--- a/ui/src/components/drafts/DraftPreview.js
+++ b/ui/src/components/drafts/DraftPreview.js
@@ -8,7 +8,7 @@ import { connect } from "react-redux";
 import Box from "grommet/components/Box";
 
 import cogoToast from "cogo-toast";
-import { EditAnchor } from "../drafts/components/Buttons";
+import { EditAnchor, Anchors } from "../drafts/components/Buttons";
 
 import JSONSchemaPreviewer from "./form/JSONSchemaPreviewer";
 import SectionBox from "../partials/SectionBox";
@@ -87,6 +87,13 @@ class DraftPreview extends React.Component {
           <Box flex={true} size={{ width: { min: "medium" } }}>
             <SectionBox
               header="Repositories"
+              headerActions={
+                <Anchors
+                  draft_id={this.props.draft_id}
+                  tab="integrations"
+                  label={this.props.canUpdate ? "Manage" : "Show"}
+                />
+              }
               body={
                 <Box pad="small">
                   <Box
@@ -135,6 +142,12 @@ class DraftPreview extends React.Component {
             />
             <SectionBox
               header="Workflows"
+              headerActions={
+                <Anchors
+                  draft_id={this.props.draft_id}
+                  label={this.props.canUpdate ? "Manage" : "Show"}
+                />
+              }
               body={
                 <Box pad="small">
                   <Box

--- a/ui/src/components/drafts/components/Buttons/Anchors.js
+++ b/ui/src/components/drafts/components/Buttons/Anchors.js
@@ -1,0 +1,30 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import Box from "grommet/components/Box";
+import Anchor from "grommet/components/Anchor";
+
+const Anchors = ({
+  draft_id = draft_id,
+  label = "",
+  tab = "",
+  icon = null
+}) => {
+  return (
+    <Box pad={{ horizontal: "small" }} justify="end">
+      <Anchor disabled={!tab} icon={icon} path={`/drafts/${draft_id}/${tab}`}>
+        {label}
+      </Anchor>
+    </Box>
+  );
+};
+
+Anchors.propTypes = {
+  history: PropTypes.object,
+  draft_id: PropTypes.string,
+  tab: PropTypes.string,
+  icon: PropTypes.node,
+  label: PropTypes.string
+};
+
+export default Anchors;

--- a/ui/src/components/drafts/components/Buttons/EditAnchor.js
+++ b/ui/src/components/drafts/components/Buttons/EditAnchor.js
@@ -1,24 +1,27 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { withRouter } from "react-router";
 
 import Box from "grommet/components/Box";
-import Anchor from "grommet/components/Anchor";
 import Label from "grommet/components/Label";
+import Anchor from "grommet/components/Anchor";
 import Edit from "grommet/components/icons/base/Edit";
 
-const EditAnchor = ({ history, draft_id = draft_id }) => {
+const EditAnchor = ({ draft_id = draft_id, icon = false }) => {
   return (
-    <Box pad={{ horizontal: "small" }}>
+    <Box pad={{ horizontal: "small" }} justify="end">
       <Anchor
-        icon={<Edit size="xsmall" />}
-        primary={true}
+        icon={icon ? <Edit size="xsmall" /> : null}
+        path={`/drafts/${draft_id}/edit`}
+        primary={icon}
         label={
-          <Label size="small" uppercase={true}>
-            Edit
-          </Label>
+          icon ? (
+            <Label size="small" uppercase={icon}>
+              Edit
+            </Label>
+          ) : (
+            "Edit"
+          )
         }
-        onClick={() => history.push(`/drafts/${draft_id}/edit`)}
       />
     </Box>
   );
@@ -26,7 +29,8 @@ const EditAnchor = ({ history, draft_id = draft_id }) => {
 
 EditAnchor.propTypes = {
   history: PropTypes.object,
-  draft_id: PropTypes.string
+  draft_id: PropTypes.string,
+  icon: PropTypes.bool
 };
 
-export default withRouter(EditAnchor);
+export default EditAnchor;

--- a/ui/src/components/drafts/components/Buttons/index.js
+++ b/ui/src/components/drafts/components/Buttons/index.js
@@ -8,3 +8,4 @@ export { default as SaveAnchor } from "./SaveAnchor";
 export { default as SettingsAnchor } from "./SettingsAnchor";
 export { default as ShareAnchor } from "./ShareAnchor";
 export { default as ShareAnchor2 } from "./ShareAnchor2";
+export { default as Anchors } from "./Anchors";

--- a/ui/src/components/partials/SectionBox.js
+++ b/ui/src/components/partials/SectionBox.js
@@ -58,7 +58,8 @@ SectionBox.propTypes = {
   body: PropTypes.node,
   headerActions: PropTypes.node,
   emptyMessage: PropTypes.string,
-  loading: PropTypes.bool
+  loading: PropTypes.bool.isRequired,
+  history: PropTypes.object
 };
 
 export default SectionBox;

--- a/ui/src/components/published/PublishedPreview.js
+++ b/ui/src/components/published/PublishedPreview.js
@@ -104,7 +104,7 @@ class PublishedPreview extends React.Component {
                 uppercase={false}
                 action={
                   this.props.canUpdate ? (
-                    <EditAnchor draft_id={this.props.draft_id} />
+                    <EditAnchor draft_id={this.props.draft_id} icon />
                   ) : null
                 }
               />


### PR DESCRIPTION
Created a new Anchors component in order to pass the link as a parameter.

There are many buttons in the folder that could be easily merged to one with parameters since the share same attributes. Needs further investigation.
Signed-off-by: papadopan <antonios.papadopan@gmail.com>