### PR TITLE
repos: create separate payload serializers for release and push events

### DIFF
--- a/cap/modules/repos/views.py
+++ b/cap/modules/repos/views.py
@@ -45,7 +45,7 @@ def get_webhook_event():
     payload = request.get_json()
     payload.update(request.headers)  # info about type of event inside headers
 
-    serializer = payload_serializer_factory()
+    serializer = payload_serializer_factory(payload)
     if not serializer:
         abort(403)
 
@@ -59,7 +59,7 @@ def get_webhook_event():
 
     try:
         webhook = GitWebhook.query.filter_by(
-            branch=data['branch'],
+            branch=data.get('branch'),
             event_type=data["event_type"],
         ).join(GitWebhook.repo).filter_by(
             external_id=data.pop('repo_id'),

--- a/tests/integration/test_view_for_gitlab_webhooks.py
+++ b/tests/integration/test_view_for_gitlab_webhooks.py
@@ -29,6 +29,7 @@ import tarfile
 import responses
 from invenio_files_rest.models import ObjectVersion
 from mock import Mock, patch
+from pytest import mark
 
 from cap.modules.repos.models import GitSnapshot
 
@@ -175,8 +176,7 @@ tag_push_payload_shortened = {
 @responses.activate
 @patch('cap.modules.repos.gitlab_api.Gitlab')
 def test_get_webhook_event_view_when_push_event(m_gitlab, deposit, client,
-                                                gitlab_push_webhook_sub,
-                                                git_repo_tar):
+                                                gitlab_push_webhook_sub, git_repo_tar):
     class MockBranchManager:
         def get(self, name):
             m = Mock(commit=dict(id='mybranchsha'))
@@ -218,7 +218,6 @@ def test_get_webhook_event_view_when_push_event(m_gitlab, deposit, client,
     assert repo_content == b'test repo for cap\n'
 
     snapshot = GitSnapshot.query.one()
-
     assert snapshot.payload == {
         'branch': 'mybranch',
         'link': 'https://gitlab.cern.ch/owner_name/myrepository/-/commit/87735e015e2b4faf60415833478dacd3174b2d1c',
@@ -242,7 +241,6 @@ def test_get_webhook_event_view_when_push_event(m_gitlab, deposit, client,
             'removed': [],
             'modified': []
         }],
-        'release': None,
         'author': {
             'name': 'owner_name',
             'id': 1
@@ -298,8 +296,6 @@ def test_get_webhook_event_view_when_release_event(m_gitlab, deposit, client,
     snapshot = GitSnapshot.query.one()
 
     assert snapshot.payload == {
-        'branch': None,
-        'commit': None,
         'event_type': 'release',
         'author': {
             'name': 'owner_name',


### PR DESCRIPTION
* closes #1534

Signed-off-by: Ilias Koutsakis <ilias.koutsakis@cern.ch>