### PR TITLE
ui: draftPreview links visible in smaller screens

### DIFF
--- a/ui/src/components/drafts/DraftPreview.js
+++ b/ui/src/components/drafts/DraftPreview.js
@@ -44,6 +44,7 @@ class DraftPreview extends React.Component {
       hideAfter: 3
     });
   }
+
   render() {
     let _schema =
       this.props.schemas && this.props.schemas.schema
@@ -59,7 +60,12 @@ class DraftPreview extends React.Component {
         wrap={true}
       >
         {this.props.error ? this.showToaster(this.props.error.message) : null}
-        <Box flex={true} pad={{ between: "medium" }} direction="row">
+        <Box
+          flex={true}
+          pad={{ between: "medium" }}
+          direction="row"
+          className="width-100"
+        >
           <Box flex={true} size={{ width: { min: "medium" } }}>
             <SectionBox
               header="Metadata"

--- a/ui/src/components/partials/SectionBox.js
+++ b/ui/src/components/partials/SectionBox.js
@@ -19,6 +19,7 @@ function SectionBox(props) {
           direction="row"
           pad={{ vertical: "small" }}
           justify="between"
+          responsive={false}
         >
           <Heading
             tag="h5"

--- a/ui/src/styles/styles.scss
+++ b/ui/src/styles/styles.scss
@@ -7,9 +7,9 @@ $vin-red: #ff0000;
   font-family: CAPFont;
   src: url("../fonts/Web-Regular.eot");
   src: url("../fonts/Web-Regular.eot") format("embedded-opentype"),
-  url("../fonts/Web-RegularItalic.eot") format("embedded-opentype"),
-  url("../fonts/Web-Regular.woff") format("woff"),
-  url("../fonts/Web-RegularItalic.woff") format("woff");
+    url("../fonts/Web-RegularItalic.eot") format("embedded-opentype"),
+    url("../fonts/Web-Regular.woff") format("woff"),
+    url("../fonts/Web-RegularItalic.woff") format("woff");
 }
 
 //@import '~grommet/scss/vanilla/index';
@@ -87,6 +87,9 @@ label {
   }
   .jst-md-center {
     justify-content: center;
+  }
+  .width-100 {
+    width: 100% !important;
   }
 }
 


### PR DESCRIPTION
Signed-off-by: papadopan <antonios.papadopan@gmail.com>

* make the DraftPreview links (Metadata, Repositories, Workflows) visible in smaller screens

### Before
![Screenshot 2020-03-25 at 15 23 54](https://user-images.githubusercontent.com/19371945/77547980-31609700-6eae-11ea-8e37-3ef0672876a5.png)

### After
![Screenshot 2020-03-25 at 15 23 39](https://user-images.githubusercontent.com/19371945/77547993-39b8d200-6eae-11ea-8f09-3c3d1d27ea76.png)
