### PR TITLE
global: start registering activities

### DIFF
--- a/cap/activities.py
+++ b/cap/activities.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of CERN Analysis Preservation Framework.
+# Copyright (C) 2016 CERN.
+#
+# CERN Analysis Preservation Framework is free software; you can redistribute
+# it and/or modify it under the terms of the GNU General Public License as
+# published by the Free Software Foundation; either version 2 of the
+# License, or (at your option) any later version.
+#
+# CERN Analysis Preservation Framework is distributed in the hope that it will
+# be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with CERN Analysis Preservation Framework; if not, write to the
+# Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston,
+# MA 02111-1307, USA.
+#
+# In applying this license, CERN does not
+# waive the privileges and immunities granted to it by virtue of its status
+# as an Intergovernmental Organization or submit itself to any jurisdiction.
+"""CAP utilities for registering activities with SQL-Continuum plugin."""
+from flask import current_app
+from invenio_db import db
+
+# list of available activities -> message to show to user (for serializers)
+ACTIVITIES = {
+    'create deposit': None,
+    'update permissions': None,
+    'publish analysis': None,
+    'reedit published analysis': None,
+    'update analysis': None,
+    'patch analysis': None,
+}
+
+
+def get_activity_model():
+    """Return SQLAlchemy activities model if registered."""
+    return getattr(current_app.extensions['invenio-db'].versioning_manager,
+                   'activity_cls', None)
+
+
+def register_activity(verb,
+                      object=None,
+                      object_id=None,
+                      data=None,
+                      target=None,
+                      target_id=None):
+    """Register activity if activities plugin on."""
+
+    activity_model = get_activity_model()
+
+    # check if activities plugin is there
+    if not activity_model:
+        return
+
+    assert isinstance(object_id, int) if object_id else True
+    assert isinstance(target_id, int) if target_id else True
+
+    assert verb in ACTIVITIES.keys()
+
+    with db.session.begin_nested():
+        db.session.add(
+            activity_model(verb=verb,
+                           data=data,
+                           object=object,
+                           object_id=object_id,
+                           target=target,
+                           target_id=target_id))

--- a/cap/alembic/bceec8433ecb_add_table_for_tracking_acitivities.py
+++ b/cap/alembic/bceec8433ecb_add_table_for_tracking_acitivities.py
@@ -1,0 +1,43 @@
+#
+# This file is part of Invenio.
+# Copyright (C) 2016-2018 CERN.
+#
+# Invenio is free software; you can redistribute it and/or modify it
+# under the terms of the MIT License; see LICENSE file for more details.
+"""Add table for tracking acitivities."""
+
+import sqlalchemy as sa
+from alembic import op
+
+from cap.types import json_type
+
+# revision identifiers, used by Alembic.
+revision = 'bceec8433ecb'
+down_revision = 'dd3ef5d1ac6f'
+branch_labels = ()
+depends_on = None
+
+
+def upgrade():
+    """Upgrade database."""
+    op.create_table(
+        'activity', sa.Column('id', sa.BigInteger(), nullable=False),
+        sa.Column('verb', sa.Unicode(length=255), nullable=True),
+        sa.Column('transaction_id', sa.BigInteger(), nullable=False),
+        sa.Column('data', json_type),
+        sa.Column('object_type', sa.String(length=255), nullable=True),
+        sa.Column('object_id', sa.BigInteger(), nullable=True),
+        sa.Column('object_tx_id', sa.BigInteger(), nullable=True),
+        sa.Column('target_type', sa.String(length=255), nullable=True),
+        sa.Column('target_id', sa.BigInteger(), nullable=True),
+        sa.Column('target_tx_id', sa.BigInteger(), nullable=True),
+        sa.PrimaryKeyConstraint('id', name=op.f('pk_activity')))
+    op.create_index(op.f('ix_activity_transaction_id'),
+                    'activity', ['transaction_id'],
+                    unique=False)
+
+
+def downgrade():
+    """Downgrade database."""
+    op.drop_index(op.f('ix_activity_transaction_id'), table_name='activity')
+    op.drop_table('activity')

--- a/cap/config.py
+++ b/cap/config.py
@@ -650,3 +650,5 @@ LOGGING_SENTRY_PYWARNINGS = False
 
 LOGGING_SENTRY_CELERY = True
 """Configure Celery to send logging to Sentry."""
+
+DB_EXTRA_PLUGINS = ['sqlalchemy_continuum.plugins.ActivityPlugin']

--- a/requirements-local-forks.txt
+++ b/requirements-local-forks.txt
@@ -1,3 +1,4 @@
+-e git+git://github.com/annatrz/invenio-db@master#egg=invenio-db[postgresql,versioning]
 -e git+git://github.com/annatrz/invenio-deposit.git#egg=invenio-deposit
 # -e git+git://github.com/reanahub/reana-client.git@master#egg=reana-client
 # -e git+git://github.com/reanahub/reana-commons.git@master#egg=reana-commons

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,7 +74,7 @@ invenio-config==1.0.0     # via invenio, invenio-app
 git+git://github.com/annatrz/invenio-deposit.git#egg=invenio-deposit
 git+git://github.com/reanahub/reana-client.git@master#egg=reana-client
 git+git://github.com/reanahub/reana-commons.git@master#egg=reana-commons
-invenio-db[postgresql,versioning]==1.0.1  # via invenio, invenio-accounts-rest, invenio-admin
+git+git://github.com/annatrz/invenio-db@master#egg=invenio-db[postgresql,versioning]
 invenio-formatter==1.0.1  # via invenio
 invenio-i18n==1.0.0       # via invenio, invenio-accounts, invenio-theme
 invenio-indexer==1.0.1    # via invenio, invenio-records-rest


### PR DESCRIPTION
last PR!
* example usage of activities for deposit create
uses a local fork, for now, but probably we should make pr to the invenio-db itself 
it's just an example, should be added to all the commands, that we want to track
* extra fix as pop_from_patch wasn't working for nested fields

Signed-off-by: Anna Trzcinska <anna.trzcinska@cern.ch>