### PR TITLE
records: fix metadata errors on new versions

### DIFF
--- a/cap/modules/deposit/api.py
+++ b/cap/modules/deposit/api.py
@@ -80,6 +80,7 @@ PRESERVE_FIELDS = (
     '_fetched_from',
     'general_title',
     '$schema',
+    'control_number'
 )
 
 DEPOSIT_ACTIONS = (


### PR DESCRIPTION
* adds `control_number` that was missing after publishing new version
* fixes permissions after new version (record instead of deposit)

Signed-off-by: Ilias Koutsakis <ilias.koutsakis@cern.ch>