### PR TITLE
ui: Repo status messages position update

### DIFF
--- a/ui/cap-react/src/components/drafts/form/themes/grommet/fields/RepoField/index.js
+++ b/ui/cap-react/src/components/drafts/form/themes/grommet/fields/RepoField/index.js
@@ -227,7 +227,9 @@ class RepoField extends React.Component {
     }
 
     if (_message.status)
-      parts.push(
+      parts.splice(
+        1,
+        0,
         <Box
           pad={{ horizontal: "small" }}
           margin="small"
@@ -275,7 +277,11 @@ class RepoField extends React.Component {
               colorIndex="light-2"
               direction="row"
               wrap="false"
-              pad={{ between: "small", horizontal: "small", vertical: "small" }}
+              pad={{
+                between: "small",
+                horizontal: "small",
+                vertical: "small"
+              }}
               align="center"
             >
               <TipIcon size="small" />


### PR DESCRIPTION

<img width="1025" alt="Screenshot 2020-07-15 at 11 45 43" src="https://user-images.githubusercontent.com/19371945/87531379-ef907200-c691-11ea-921a-fc46247722e7.png">

Signed-off-by: papadopan <antonios.papadopan@gmail.com>

* closes #1678