### PR TITLE
ui: Repo responsive, and lost focus fixed

### DIFF
--- a/ui/cap-react/src/components/drafts/form/themes/grommet/fields/RepoField/RepoActions.js
+++ b/ui/cap-react/src/components/drafts/form/themes/grommet/fields/RepoField/RepoActions.js
@@ -108,31 +108,25 @@ class RepoActions extends React.Component {
         colorIndex="light-2"
         justify="between"
         align="center"
+        responsive={false}
       >
         <Box
           flex
           pad={{ between: "medium" }}
           margin={{ right: "medium" }}
           direction="row"
+          responsive={false}
           justify="center"
           align="center"
         >
           <Box flex={true}>
-            <Box
-              justify="start"
-              pad={{
-                horizontal: "small",
-                vertical: "small",
-                between: "medium"
-              }}
-            >
+            <Box justify="start" pad="small">
               <Box>
                 <Heading strong tag="h5" margin="none">
                   You have selected the following repository:
                 </Heading>
 
                 <Box
-                  flex={false}
                   align="start"
                   pad="small"
                   separator="all"
@@ -140,12 +134,17 @@ class RepoActions extends React.Component {
                   margin={{ vertical: "small" }}
                 >
                   <Box
+                    responsive={false}
                     direction="row"
-                    wrap={false}
                     margin={{ bottom: "small" }}
                   >
                     {this.renderResourceIcon(resource)}
-                    <Label size="small" announce={true} margin="none">
+                    <Label
+                      size="small"
+                      announce={true}
+                      margin="none"
+                      style={{ wordBreak: "break-word" }}
+                    >
                       <a>
                         <strong>
                           {owner && owner != "" && name && name != ""
@@ -162,6 +161,7 @@ class RepoActions extends React.Component {
                       align="center"
                       justify="start"
                       direction="row"
+                      responsive={false}
                       wrap={false}
                     >
                       <Box colorIndex="grey-3" pad={{ horizontal: "small" }}>
@@ -191,6 +191,7 @@ class RepoActions extends React.Component {
                         align="center"
                         justify="start"
                         direction="row"
+                        responsive={false}
                         wrap={false}
                       >
                         <Box colorIndex="grey-3" pad={{ horizontal: "small" }}>

--- a/ui/cap-react/src/components/drafts/form/themes/grommet/fields/RepoField/index.js
+++ b/ui/cap-react/src/components/drafts/form/themes/grommet/fields/RepoField/index.js
@@ -156,6 +156,7 @@ class RepoField extends React.Component {
           direction="row"
           align="center"
           justify="between"
+          responsive={false}
         >
           <Box flex={true}>
             <TextInput

--- a/ui/cap-react/src/components/partials/EditableField.js
+++ b/ui/cap-react/src/components/partials/EditableField.js
@@ -86,6 +86,7 @@ class EditableField extends React.Component {
             onChange={this._onChange}
             value={this.state.value}
             autoFocus={true}
+            onClick={e => e.stopPropagation()}
           />
         </Label>
         <Box margin="none" direction="row" align="center" responsive={false}>
@@ -107,6 +108,7 @@ class EditableField extends React.Component {
           align="center"
           key="draft-title"
           direction="row"
+          responsive={false}
           wrap={false}
           onMouseEnter={this._hoverIn}
           onMouseLeave={this._hoverOut}

--- a/ui/cap-react/src/styles/styles.scss
+++ b/ui/cap-react/src/styles/styles.scss
@@ -313,8 +313,12 @@ label {
 
 
 
+
+
 // xsmall
 @media only screen and (min-width: 320px) {
+
+  
   .footer-items{
     padding: 5px !important;
   }


### PR DESCRIPTION
Signed-off-by: papadopan <antonios.papadopan@gmail.com>

* closes #1709 
* closes #1766 

- Also user can edit the branch without losing focus

![Screenshot 2020-07-20 at 16 09 43](https://user-images.githubusercontent.com/19371945/87947344-7c2c9d00-caa3-11ea-97de-90b7455ccf28.png)
