### PR TITLE
ui: update search shortcut url, for published records

### DIFF
--- a/ui/cap-react/src/components/search/SearchFacet/SearchFacet.js
+++ b/ui/cap-react/src/components/search/SearchFacet/SearchFacet.js
@@ -22,7 +22,7 @@ const SearchFacet = ({
   updateFacet
 }) => {
   let expanded = !collapsed.toJS().includes(category);
-  let facet = facets[category]
+  let facet = facets[category];
   return (
     <Box>
       <Box
@@ -45,7 +45,9 @@ const SearchFacet = ({
           id={category}
           value={category}
         >
-          {facet.meta && facet.meta.title ? facet.meta.title : category.replace("_", " ")}
+          {facet.meta && facet.meta.title
+            ? facet.meta.title
+            : category.replace("_", " ")}
         </Heading>
 
         <Box onClick={() => updateFacet(category)}>

--- a/ui/cap-react/src/components/search/SearchFacets.js
+++ b/ui/cap-react/src/components/search/SearchFacets.js
@@ -153,8 +153,24 @@ class SearchFacets extends React.Component {
 
   updateCategory = () => {
     let location = this.props.location;
-    location.pathname = location.pathname === "/search" ? "/drafts" : "/search";
+
+    let anatype = this.props.match.params.anatype;
+
+    location.pathname = location.pathname.startsWith("/search")
+      ? "/drafts"
+      : "/search";
     this.setState({ categoryScope: location.pathname });
+
+    // if the anatype exists means that the user needs a specific type of analysis
+    // in the event that the user wants to search through the drafts, the type should be maintained
+    if (anatype) {
+      let currentParams = queryString.parse(this.props.location.search);
+      currentParams["type"] = anatype;
+      location = {
+        search: queryString.stringify(currentParams)
+      };
+    }
+
     this.props.history.push(location);
   };
 
@@ -218,7 +234,7 @@ class SearchFacets extends React.Component {
                 toggle={true}
                 reverse={false}
                 onChange={this.updateCategory}
-                checked={this.state.categoryScope === "/search"}
+                checked={this.state.categoryScope.startsWith("/search")}
               />
             </Box>
             <Box
@@ -250,7 +266,8 @@ SearchFacets.propTypes = {
   location: PropTypes.object.isRequired,
   selectedAggs: PropTypes.object.isRequired,
   loading: PropTypes.bool,
-  removeType: PropTypes.string
+  removeType: PropTypes.string,
+  match: PropTypes.object
 };
 
 function mapStateToProps(state) {


### PR DESCRIPTION
- [X] Update the checked condition to validate whether the location.pathname startsWith instead of equal
- [X] When the user updates the filters for drafts from the url shortcut (/search/cms-analysis) to maintain the type and update the params in the history object

* solves #1818