### PR TITLE
ui: JSONSchemaPreviewer layout fixes

### DIFF
--- a/ui/cap-react/src/components/drafts/DraftPreview.js
+++ b/ui/cap-react/src/components/drafts/DraftPreview.js
@@ -71,6 +71,7 @@ class DraftPreview extends React.Component {
           <Box flex={true} size={{ width: { min: "medium" } }} basis="3/4">
             <SectionBox
               header="Metadata"
+              className="box-large-height"
               headerActions={
                 this.props.canUpdate ? (
                   <Anchor

--- a/ui/cap-react/src/components/drafts/DraftPreview.js
+++ b/ui/cap-react/src/components/drafts/DraftPreview.js
@@ -84,7 +84,7 @@ class DraftPreview extends React.Component {
               }
               body={
                 this.props.schemas && this.props.schemas.schema ? (
-                  <Box flex={true} pad="small">
+                  <Box flex={true}>
                     <JSONSchemaPreviewer
                       formData={this.props.metadata}
                       schema={_schema}

--- a/ui/cap-react/src/components/drafts/form/JSONSchemaPreviewer.js
+++ b/ui/cap-react/src/components/drafts/form/JSONSchemaPreviewer.js
@@ -77,7 +77,7 @@ class JSONShemaPreviewer extends React.Component {
       <Box
         flex={true}
         pad={{ horizontal: "small" }}
-        style={{ position: "relative", height: "1px" }}
+        style={{ position: "relative", height: "1vh" }}
       >
         {!this.props.draft && (
           <Box

--- a/ui/cap-react/src/components/drafts/form/JSONSchemaPreviewer.js
+++ b/ui/cap-react/src/components/drafts/form/JSONSchemaPreviewer.js
@@ -45,7 +45,7 @@ class JSONShemaPreviewer extends React.Component {
 
     this.state = {
       formData: {},
-      uiObject: shouldDisplayTabViewButton ? "tabView" : "",
+      uiObject: this.props.draft ? "" : (shouldDisplayTabViewButton ? "tabView" : ""),
       uiAvailableList: shouldDisplayTabViewButton
         ? [
             {

--- a/ui/cap-react/src/components/partials/SectionBox.js
+++ b/ui/cap-react/src/components/partials/SectionBox.js
@@ -9,7 +9,14 @@ import Box from "grommet/components/Box";
 import Heading from "grommet/components/Heading";
 
 function SectionBox(props) {
-  let { headerActions, header = "", body, emptyMessage = null, more } = props;
+  let {
+    headerActions,
+    header = "",
+    body,
+    emptyMessage = null,
+    more,
+    className = ""
+  } = props;
 
   return (
     <Box flex={false} margin={{ bottom: "small" }}>
@@ -37,11 +44,7 @@ function SectionBox(props) {
         <ReactTooltip />
       </Box>
 
-      <Box
-        colorIndex="light-2"
-        flex={false}
-        size={{ height: { max: "large" } }}
-      >
+      <Box colorIndex="light-2" flex={false} className={className}>
         {body}
       </Box>
       {more && (
@@ -59,7 +62,8 @@ SectionBox.propTypes = {
   body: PropTypes.node,
   headerActions: PropTypes.node,
   emptyMessage: PropTypes.string,
-  history: PropTypes.object
+  history: PropTypes.object,
+  className: PropTypes.string
 };
 
 export default SectionBox;

--- a/ui/cap-react/src/styles/styles.scss
+++ b/ui/cap-react/src/styles/styles.scss
@@ -246,7 +246,9 @@ label {
   max-width: 100%;
   display: flex;
   margin: 0 auto;
+  margin-top: auto;
 }
+
 .fieldTemplate:nth-child(even) {
   background: #f5f5f5 !important;
 }
@@ -351,6 +353,13 @@ label {
 
 // xsmall
 @media only screen and (min-width: 320px) {
+  //TODO: Update for better handling with grid
+  .box-large-height {
+    max-width: 100%;
+    max-height: 100%;
+    height: 100%;
+    min-height: 40vh;
+  }
   .animated-nav-wrapper {
     position: relative;
     min-width: 48px;

--- a/ui/cap-react/src/styles/styles.scss
+++ b/ui/cap-react/src/styles/styles.scss
@@ -373,9 +373,6 @@ label {
     display: flex !important;
     flex-direction: column-reverse !important;
   }
-  .display-only-for-small {
-    display: flex !important;
-  }
 
   .tab-scroll {
     height: 1vh !important;
@@ -427,6 +424,7 @@ label {
   #item {
     min-width: 250px;
     align-items: center;
+    display: flex;
     justify-content: center;
   }
 
@@ -614,7 +612,7 @@ label {
   #list {
     overflow-x: auto;
     justify-content: flex-start;
-    max-width: 91vw;
+    max-width: 90vw;
   }
   .tabs-list-items {
     display: flex !important;
@@ -630,9 +628,6 @@ label {
 }
 
 @media only screen and (min-width: 850px) {
-  #list {
-    max-width: 91.5vw;
-  }
   .xlarge_box {
     width: 750px;
   }
@@ -640,9 +635,10 @@ label {
     justify-content: center;
   }
 }
+
 @media only screen and (min-width: 910px) {
   #list {
-    max-width: 92vw;
+    max-width: 90.5vw;
   }
   .footer-order {
     display: flex !important;
@@ -650,9 +646,15 @@ label {
   }
 }
 
+@media only screen and (min-width: 920px) {
+  #list {
+    max-width: 91vw;
+  }
+}
+
 @media only screen and (min-width: 992px) {
   #list {
-    max-width: 92.5vw;
+    max-width: 92vw;
   }
   .search_result_box {
     min-width: 615px !important;
@@ -667,11 +669,6 @@ label {
   }
 }
 
-@media only screen and (min-width: 1050px) {
-  #list {
-    max-width: 93vw;
-  }
-}
 @media only screen and (min-width: 1070px) {
   .menuItem::after {
     content: "";
@@ -687,12 +684,6 @@ label {
     transition: width 0.3s;
   }
 }
-// large
-@media only screen and (min-width: 1135px) {
-  #list {
-    max-width: 93.5vw;
-  }
-}
 
 // large
 @media only screen and (min-width: 1179px) {
@@ -701,28 +692,12 @@ label {
   }
 }
 
-@media only screen and (min-width: 1220px) {
-  #list {
-    max-width: 94vw;
-  }
-}
-@media only screen and (min-width: 1320px) {
-  #list {
-    max-width: 94.5vw;
-  }
-}
-
-// xlarge
-
-@media only screen and (min-width: 1450px) {
+@media only screen and (min-width: 1114px) {
   .sidebar-hide-small {
     position: unset !important;
   }
   .lg-column {
     flex-direction: row !important;
-  }
-  .display-only-for-small {
-    display: none !important;
   }
 
   .lg-row {


### PR DESCRIPTION
* ui: update the media queries for the edit page
* ui: css fixes for jsonschemapreviewer
* ui: draftItem - change metadata preview mode to 'list'

closes #1863, closes #1871 