### PR TITLE
ui: fix grommet horizontal padding for small screens

### DIFF
--- a/ui/cap-react/src/components/drafts/form/themes/grommet/components/FormLayer.js
+++ b/ui/cap-react/src/components/drafts/form/themes/grommet/components/FormLayer.js
@@ -26,7 +26,12 @@ class FormLayer extends React.Component {
           <Box pad="medium" size="large">
             <Box>{this.props.properties}</Box>
 
-            <Box direction="row" justify="between" pad={{ vertical: "small" }}>
+            <Box
+              direction="row"
+              justify="between"
+              pad={{ vertical: "small" }}
+              responsive={false}
+            >
               <Box>
                 {this.props.remove ? (
                   <Button

--- a/ui/cap-react/src/components/drafts/form/themes/grommet/widgets/RadioWidget.js
+++ b/ui/cap-react/src/components/drafts/form/themes/grommet/widgets/RadioWidget.js
@@ -33,7 +33,7 @@ const RadioWidget = function(props) {
   };
 
   return (
-    <Box direction="row" pad={{ horizontal: "medium" }} flex={false}>
+    <Box direction="row" pad={{ horizontal: "medium" }} responsive={false}>
       {options.enumOptions.length > 0
         ? options.enumOptions.map(item => (
             <RadioButton

--- a/ui/cap-react/src/styles/styles.scss
+++ b/ui/cap-react/src/styles/styles.scss
@@ -358,6 +358,12 @@ label {
 
 // xsmall
 @media only screen and (min-width: 320px) {
+  // grommet padding changes when smaller screens
+  // make sure to keep it consistent
+  .grommetux-form-field__contents > div.grommetux-box--pad-horizontal-medium {
+    padding: 0 24px;
+  }
+
   //TODO: Update for better handling with grid
   .box-large-height {
     max-width: 100%;


### PR DESCRIPTION
Signed-off-by: papadopan <antonios.papadopan@gmail.com>
* Before
![Screenshot 2020-10-13 at 15 01 01](https://user-images.githubusercontent.com/19371945/95864368-98b83880-0d65-11eb-8e5e-502d3b4270b7.png)
![Screenshot 2020-10-13 at 15 01 09](https://user-images.githubusercontent.com/19371945/95864373-99e96580-0d65-11eb-848c-1ef50500fd5c.png)
* After
![Screenshot 2020-10-13 at 15 01 20](https://user-images.githubusercontent.com/19371945/95864376-99e96580-0d65-11eb-809f-9d9a34add593.png)
![Screenshot 2020-10-13 at 15 01 26](https://user-images.githubusercontent.com/19371945/95864378-9a81fc00-0d65-11eb-8fcf-b574608e5757.png)


* closes #1885 


