### PR TITLE
deposits: add serializer for deposit `access`

### DIFF
--- a/cap/modules/deposit/serializers/__init__.py
+++ b/cap/modules/deposit/serializers/__init__.py
@@ -30,13 +30,14 @@ from invenio_records_rest.serializers.response import (record_responsify,
                                                        search_responsify)
 
 from .json import DepositSerializer
-from .schemas.json import DepositSchema, DepositFormSchema
+from .schemas.json import DepositSchema, DepositFormSchema, DepositSearchSchema
 
 # Serializers
 # ===========
 # CAP JSON serializer version 1.0.0
 deposit_json_v1 = DepositSerializer(DepositSchema)
 deposit_form_json_v1 = DepositSerializer(DepositFormSchema)
+deposit_search_json_v1 = DepositSerializer(DepositSearchSchema)
 
 # Records-REST serializers
 # ========================
@@ -45,8 +46,10 @@ deposit_json_v1_response = record_responsify(deposit_json_v1,
                                              'application/json')
 deposit_form_json_v1_response = record_responsify(deposit_form_json_v1,
                                                   'application/json')
-deposit_json_v1_search = search_responsify(deposit_json_v1, 'application/json')
+deposit_json_v1_search = search_responsify(deposit_search_json_v1,
+                                           'application/json')
 
 # Files-REST serializers
+# ========================
 # JSON Files serializers for deposit files
 files_response = json_file_response

--- a/cap/modules/records/serializers/schemas/common.py
+++ b/cap/modules/records/serializers/schemas/common.py
@@ -99,8 +99,6 @@ class CommonRecordSchema(Schema, StrictKeysMixin):
     links = fields.Raw(dump_only=True)
     files = fields.Method('get_files', dump_only=True)
 
-    access = fields.Method('get_access', dump_only=True)
-
     created = fields.Str(dump_only=True)
     updated = fields.Str(dump_only=True)
 
@@ -150,20 +148,6 @@ class CommonRecordSchema(Schema, StrictKeysMixin):
 
         return get_remote_account_by_id(user_id) \
             if user_id else None
-
-    def get_access(self, obj):
-        """Return access object."""
-        access = obj.get('metadata', {})['_access']
-
-        for permission in access.values():
-            if permission['users']:
-                for index, user_id in enumerate(permission['users']):
-                    permission['users'][index] = get_remote_account_by_id(user_id)  # noqa
-            if permission['roles']:
-                for index, role_id in enumerate(permission['roles']):
-                    permission['roles'][index] = get_role_name_by_id(role_id)
-
-        return access
 
     def get_labels(self, obj):
         """Get labels."""

--- a/scripts/cap.wordlist
+++ b/scripts/cap.wordlist
@@ -22,5 +22,6 @@ LDAP
 invenio
 oauthclient
 serializers
+serializer
 schemas
 url

--- a/tests/integration/deposits/test_get_deposits.py
+++ b/tests/integration/deposits/test_get_deposits.py
@@ -277,20 +277,6 @@ def test_get_deposit_with_default_serializer(client, users,
             'size': file.file.size,
             'version_id': str(file.version_id)
         }],
-        'access': {
-            'deposit-admin': {
-                'roles': [],
-                'users': [{'email': owner.email, 'profile': {}}],
-            },
-            'deposit-update': {
-                'roles': [],
-                'users': [{'email': owner.email, 'profile': {}}],
-            },
-            'deposit-read': {
-                'roles': [],
-                'users': [{'email': owner.email, 'profile': {}}],
-            }
-        },
         'is_owner': True,
         'links': {
             'bucket': 'http://analysispreservation.cern.ch/api/files/{}'.


### PR DESCRIPTION
* uses a new serializer for search, that does not include
all the profile info in the `access` field

Signed-off-by: Ilias Koutsakis <ilias.koutsakis@cern.ch>