### PR TITLE
ui: display and edit schemas

### DIFF
--- a/.githooks/prepare-commit-msg
+++ b/.githooks/prepare-commit-msg
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+COMMIT_MSG_FILE=$1
+SOB=$(git var GIT_COMMITTER_IDENT | sed -n 's/^\(.*>\).*$/Signed-off-by: \1/p')
+git interpret-trailers --in-place --trailer "$SOB" "$COMMIT_MSG_FILE"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,3 +60,9 @@ repos:
         entry: .githooks/pre-push
         language: system
         stages: [push]
+
+      - id: add_signed_off_by
+        name: add_signed_off_by
+        entry: .githooks/prepare-commit-msg
+        language: system
+        stages: [prepare-commit-msg]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,28 +4,28 @@ repos:
     rev: 22.3.0
     hooks:
       - id: black
-        args: ['--skip-string-normalization']
+        args: ["--skip-string-normalization"]
         exclude: ^tests/
 
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: '3.9.2'
+  - repo: https://github.com/pycqa/flake8
+    rev: "3.9.2"
     hooks:
       - id: flake8
-        args: ['--config=.flake8']
+        args: ["--config=.flake8"]
 
   - repo: https://github.com/pycqa/isort
-    rev: '5.10.1'
+    rev: "5.10.1"
     hooks:
       - id: isort
 
-  - repo: https://gitlab.com/pycqa/pydocstyle
-    rev: '6.1.1'
+  - repo: https://github.com/pycqa/pydocstyle
+    rev: "6.1.1"
     hooks:
       - id: pydocstyle
 
   # JS
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: 'v2.7.1'
+    rev: "v2.7.1"
     hooks:
       - id: prettier
         stages: [commit, push]
@@ -33,7 +33,7 @@ repos:
 
   # Project Wide
   - repo: https://github.com/jorisroovers/gitlint
-    rev: 'v0.17.0'
+    rev: "v0.17.0"
     hooks:
       - id: gitlint
         language: python

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -150,7 +150,7 @@ Setup Instructions:
 
 1. Install pre-commit: `pip install pre-commit`
 2. Install the git hook script: `pre-commit install`
-3. Install different hook types: `pre-commit install --hook-type pre-commit --hook-type pre-push --hook-type commit-msg`
+3. Install different hook types: `pre-commit install --hook-type pre-commit --hook-type pre-push --hook-type prepare-commit-msg --hook-type commit-msg`
 
 `pre-commit` will now run on every commit. 
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -33,9 +33,10 @@ services:
     extends:
       file: docker-services.yml
       service: app
-    command: gunicorn -b 0.0.0.0:5000 --access-logfile "-" --reload --log-level debug cap.wsgi:application
+    # command: gunicorn -b 0.0.0.0:5000 --access-logfile "-" --reload --log-level debug cap.wsgi:application
+    command: cap run --host=0.0.0.0 --reload
     ports:
-      - "5000"
+      - "5000:5000"
     volumes:
       - static_data:/opt/cap/var/instance/static
       - uploaded_data:/opt/cap/var/instance/data
@@ -58,7 +59,8 @@ services:
     extends:
       file: docker-services.yml
       service: app
-    command: gunicorn -b 0.0.0.0:5000 --access-logfile "-" --reload --log-level debug cap.wsgi:application
+    # command: gunicorn -b 0.0.0.0:5000 --access-logfile "-" --reload --log-level debug cap.wsgi:application
+    command: cap run --host=0.0.0.0 --reload
     ports:
       - "5000"
     volumes:
@@ -85,12 +87,12 @@ services:
       - mq
       - db
   # Monitoring
-  flower:
-    extends:
-      file: docker-services.yml
-      service: flower
-    links:
-      - mq
+  # flower:
+  #   extends:
+  #     file: docker-services.yml
+  #     service: flower
+  #   links:
+  #     - mq
   # Base services
   cache:
     extends:

--- a/ui/cap-react/package.json
+++ b/ui/cap-react/package.json
@@ -37,6 +37,11 @@
   "license": "MIT",
   "dependencies": {
     "@ant-design/icons": "4.7.0",
+    "@codemirror/commands": "6.1.2",
+    "@codemirror/lang-json": "6.0.1",
+    "@codemirror/lint": "6.1.0",
+    "@codemirror/state": "6.1.3",
+    "@codemirror/view": "6.4.2",
     "@rjsf/antd": "3.2.1",
     "@rjsf/core": "3.2.1",
     "@sentry/browser": "5.15.4",
@@ -45,6 +50,7 @@
     "antd": "4.18.3",
     "classnames": "2.3.1",
     "clean-deep": "3.3.0",
+    "codemirror": "6.0.1",
     "cogo-toast": "4.1.1",
     "connected-react-router": "6.5.2",
     "dayjs": "1.10.7",
@@ -75,7 +81,7 @@
     "query-string": "^5.1.0",
     "rc-pagination": "3.1.6",
     "rc-select": "12.1.10",
-    "react": "^16.6.0",
+    "react": "^16.14.0",
     "react-ace": "8.0.0",
     "react-compound-slider": "2.5.0",
     "react-copy-to-clipboard": "5.0.4",
@@ -114,8 +120,8 @@
     "reselect": "^3.0.1",
     "sanitize-html": "2.4.0",
     "searchkit": "2.3.0",
-    "styled-components": "4.4.1",
-    "squirrelly": "8.0.8"
+    "squirrelly": "8.0.8",
+    "styled-components": "4.4.1"
   },
   "devDependencies": {
     "@sambego/storybook-state": "2.0.1",

--- a/ui/cap-react/package.json
+++ b/ui/cap-react/package.json
@@ -160,7 +160,6 @@
     "file-loader": "1.1.11",
     "history": "^4.7.2",
     "html-webpack-plugin": "3.2.0",
-    "husky": "0.14.3",
     "identity-obj-proxy": "3.0.0",
     "jest": "20.0.4",
     "jest-cli": "20.0.4",

--- a/ui/cap-react/src/antd/App/App.js
+++ b/ui/cap-react/src/antd/App/App.js
@@ -7,6 +7,7 @@ import IndexPage from "../index/IndexPage";
 
 import AboutPage from "../about";
 import PolicyPage from "../policy";
+import SchemasPage from "../schemas";
 
 import noRequireAuth from "../auth/NoAuthorizationRequired";
 import requireAuth from "../auth/AuthorizationRequired";
@@ -18,7 +19,7 @@ import DocumentTitle from "../partials/DocumentTitle";
 import { Layout, Row, Spin } from "antd";
 
 import Loadable from "react-loadable";
-import { HOME, WELCOME, ABOUT, POLICY, CMS } from "../routes";
+import { HOME, WELCOME, ABOUT, POLICY, CMS, SCHEMAS } from "../routes";
 import Loading from "../routes/Loading";
 
 const CMSIndex = Loadable({
@@ -53,6 +54,7 @@ const App = ({ initCurrentUser, loadingInit, history }) => {
             <Route path={ABOUT} component={AboutPage} />
             <Route path={POLICY} component={PolicyPage} />
             <Route path={CMS} component={CMSIndex} />
+            <Route path={SCHEMAS} component={SchemasPage} />
             <Route path={HOME} component={requireAuth(IndexPage)} />
           </Switch>
         </Layout.Content>

--- a/ui/cap-react/src/antd/routes/index.js
+++ b/ui/cap-react/src/antd/routes/index.js
@@ -5,6 +5,7 @@ export const ABOUT = "/about";
 export const POLICY = "/policy";
 export const SEARCH_TIPS = "/search-tips";
 export const STATUS = "/status";
+export const SCHEMAS = "/schemas/:schema_name/:schema_version?";
 
 export const CMS = "/admin";
 export const CMS_NEW = `${CMS}/new`;

--- a/ui/cap-react/src/antd/schemas/Schemas.js
+++ b/ui/cap-react/src/antd/schemas/Schemas.js
@@ -11,7 +11,6 @@ import {
   notification,
   Tooltip,
 } from "antd";
-import JsonDiff from "../../components/cms/components/SchemaWizard/JSONDiff";
 import {
   DiffOutlined,
   InfoCircleOutlined,
@@ -19,6 +18,8 @@ import {
   UndoOutlined,
 } from "@ant-design/icons";
 import ErrorScreen from "../partials/Error";
+// TODO: move JSONEditor to antd or use codemirror/merge (pre-release)
+import JsonDiff from "../../components/cms/components/SchemaWizard/JSONDiff";
 import CodeEditor from "../util/CodeEditor";
 
 const Schemas = ({ match }) => {
@@ -47,19 +48,19 @@ const Schemas = ({ match }) => {
   const [jsonError, setJsonError] = useState();
   const [error, setError] = useState();
 
-  const generateOptions = data => {
+  const generateOptions = (data) => {
     const excludeRecordFields =
       "use_deposit_as_record" in data && data["use_deposit_as_record"] === true;
     let opts = Object.entries(data)
       .filter(
-        e =>
+        (e) =>
           typeof e[1] === "object" &&
           e[1] !== null &&
           !Array.isArray(e[1]) &&
           !HIDDEN_FIELDS.includes(e[0]) &&
           (!excludeRecordFields || !e[0].startsWith("record_"))
       )
-      .map(e => ({
+      .map((e) => ({
         label: e[0],
         value: e[0],
       }));
@@ -70,7 +71,7 @@ const Schemas = ({ match }) => {
   useEffect(() => {
     axios
       .get(`/api/jsonschemas/${schema_name}/${schema_version || ""}`)
-      .then(res => {
+      .then((res) => {
         setOriginalSchema(res.data);
         setSchema(res.data);
         setField(res.data);
@@ -101,7 +102,7 @@ const Schemas = ({ match }) => {
     setJsonError(false);
   };
 
-  const handleEdit = value => {
+  const handleEdit = (value) => {
     try {
       setField(JSON.parse(value));
       setJsonError(false);
@@ -213,8 +214,8 @@ const Schemas = ({ match }) => {
                         jsonError
                           ? "Please fix the syntax errors to be able to view the diff"
                           : selection === FULL_SCHEMA
-                            ? "View the full diff"
-                            : "View field diff"
+                          ? "View the full diff"
+                          : "View field diff"
                       }
                     >
                       <Button
@@ -243,10 +244,10 @@ const Schemas = ({ match }) => {
                         jsonError
                           ? "Please fix the syntax errors to be able to save changes"
                           : selection === FULL_SCHEMA
-                            ? "Save all changes"
-                            : !EDITABLE_FIELDS.includes(selection)
-                              ? "Please select an editable field to be able to edit and save the changes"
-                              : "Save changes to this field"
+                          ? "Save all changes"
+                          : !EDITABLE_FIELDS.includes(selection)
+                          ? "Please select an editable field to be able to edit and save the changes"
+                          : "Save changes to this field"
                       }
                     >
                       <Button

--- a/ui/cap-react/src/antd/schemas/Schemas.js
+++ b/ui/cap-react/src/antd/schemas/Schemas.js
@@ -19,6 +19,7 @@ import {
   UndoOutlined,
 } from "@ant-design/icons";
 import JSONInput from "react-json-editor-ajrm";
+import ErrorScreen from "../partials/Error";
 
 const Schemas = ({ match }) => {
   const EDITABLE_FIELDS = [
@@ -42,6 +43,7 @@ const Schemas = ({ match }) => {
   const [options, setOptions] = useState();
   const [showModal, setShowModal] = useState();
   const [jsonError, setJsonError] = useState();
+  const [error, setError] = useState();
 
   useEffect(() => {
     axios
@@ -61,6 +63,9 @@ const Schemas = ({ match }) => {
           }));
         opts.unshift({ label: FULL_SCHEMA, value: "all" });
         setOptions(opts);
+      })
+      .catch(() => {
+        setError(true);
       });
   }, []);
 
@@ -120,133 +125,137 @@ const Schemas = ({ match }) => {
 
   return (
     <DocumentTitle title="Schemas">
-      <React.Fragment>
-        <Modal
-          visible={showModal}
-          onCancel={() => setShowModal(false)}
-          title={`${selection} diff`}
-          width={800}
-          footer={null}
-          bodyStyle={{
-            overflowX: "scroll",
-            overflowY: "auto",
-            maxHeight: "calc(100vh - 200px)",
-          }}
-        >
-          <JsonDiff
-            left={
-              selection === FULL_SCHEMA
-                ? originalSchema
-                : originalSchema[selection]
-            }
-            right={field}
-          />
-        </Modal>
-        <Row justify="center">
-          <Col xs={22} lg={14}>
-            <Row
-              justify="space-between"
-              align="middle"
-              style={{ marginBottom: "1em" }}
-              gutter={10}
-            >
-              <Col flex="auto">
-                <Typography.Title style={{ marginBottom: "0" }}>
-                  {schema_name} {schema_version}
-                </Typography.Title>
-              </Col>
-              <Col>
-                <Tooltip
-                  placement="bottom"
-                  title="Select a field to edit it (if it is editable). 
+      {error ? (
+        <ErrorScreen />
+      ) : (
+        <React.Fragment>
+          <Modal
+            visible={showModal}
+            onCancel={() => setShowModal(false)}
+            title={`${selection} diff`}
+            width={800}
+            footer={null}
+            bodyStyle={{
+              overflowX: "scroll",
+              overflowY: "auto",
+              maxHeight: "calc(100vh - 200px)",
+            }}
+          >
+            <JsonDiff
+              left={
+                selection === FULL_SCHEMA
+                  ? originalSchema
+                  : originalSchema[selection]
+              }
+              right={field}
+            />
+          </Modal>
+          <Row justify="center">
+            <Col xs={22} lg={14}>
+              <Row
+                justify="space-between"
+                align="middle"
+                style={{ marginBottom: "1em" }}
+                gutter={10}
+              >
+                <Col flex="auto">
+                  <Typography.Title style={{ marginBottom: "0" }}>
+                    {schema_name} {schema_version}
+                  </Typography.Title>
+                </Col>
+                <Col>
+                  <Tooltip
+                    placement="bottom"
+                    title="Select a field to edit it (if it is editable). 
                   Check the diff, revert or save the changes to that field, 
                   or go back to 'Full schema' to check the full diff, 
                   revert or save all changes at once."
-                >
-                  <InfoCircleOutlined />
-                </Tooltip>
-              </Col>
-              <Col xs={15} md={6}>
-                {schema && (
-                  <Select
-                    style={{
-                      width: "100%",
-                    }}
-                    options={options}
-                    onChange={handleSelectChange}
-                    defaultValue="all"
-                  />
-                )}
-              </Col>
-              <Col>
-                <Tooltip
-                  placement="bottom"
-                  title={
-                    jsonError
-                      ? "Please fix the syntax errors to be able to view the diff"
-                      : selection === FULL_SCHEMA
-                        ? "View full diff"
-                        : "View field diff"
-                  }
-                >
-                  <Button
-                    icon={<DiffOutlined />}
-                    onClick={() => setShowModal(true)}
-                    disabled={jsonError}
-                  />
-                </Tooltip>
-              </Col>
-              <Col>
-                <Tooltip
-                  placement="bottom"
-                  title={
-                    selection === FULL_SCHEMA
-                      ? "Revert all unsaved changes"
-                      : "Revert unsaved changes to this field"
-                  }
-                >
-                  <Button icon={<UndoOutlined />} onClick={handleRevert} />
-                </Tooltip>
-              </Col>
-              <Col>
-                <Tooltip
-                  placement="bottom"
-                  title={
-                    selection === FULL_SCHEMA
-                      ? "Save all changes"
-                      : !EDITABLE_FIELDS.includes(selection)
-                        ? "Please select an editable field to be able to edit and save the changes"
-                        : "Save changes to this field"
-                  }
-                >
-                  <Button
-                    icon={<SaveOutlined />}
-                    type="primary"
-                    onClick={handleSave}
-                    disabled={
-                      !EDITABLE_FIELDS.includes(selection) &&
-                      selection != FULL_SCHEMA
+                  >
+                    <InfoCircleOutlined />
+                  </Tooltip>
+                </Col>
+                <Col xs={15} md={6}>
+                  {schema && (
+                    <Select
+                      style={{
+                        width: "100%",
+                      }}
+                      options={options}
+                      onChange={handleSelectChange}
+                      defaultValue="all"
+                    />
+                  )}
+                </Col>
+                <Col>
+                  <Tooltip
+                    placement="bottom"
+                    title={
+                      jsonError
+                        ? "Please fix the syntax errors to be able to view the diff"
+                        : selection === FULL_SCHEMA
+                          ? "View full diff"
+                          : "View field diff"
                     }
+                  >
+                    <Button
+                      icon={<DiffOutlined />}
+                      onClick={() => setShowModal(true)}
+                      disabled={jsonError}
+                    />
+                  </Tooltip>
+                </Col>
+                <Col>
+                  <Tooltip
+                    placement="bottom"
+                    title={
+                      selection === FULL_SCHEMA
+                        ? "Revert all unsaved changes"
+                        : "Revert unsaved changes to this field"
+                    }
+                  >
+                    <Button icon={<UndoOutlined />} onClick={handleRevert} />
+                  </Tooltip>
+                </Col>
+                <Col>
+                  <Tooltip
+                    placement="bottom"
+                    title={
+                      selection === FULL_SCHEMA
+                        ? "Save all changes"
+                        : !EDITABLE_FIELDS.includes(selection)
+                          ? "Please select an editable field to be able to edit and save the changes"
+                          : "Save changes to this field"
+                    }
+                  >
+                    <Button
+                      icon={<SaveOutlined />}
+                      type="primary"
+                      onClick={handleSave}
+                      disabled={
+                        !EDITABLE_FIELDS.includes(selection) &&
+                        selection != FULL_SCHEMA
+                      }
+                    />
+                  </Tooltip>
+                </Col>
+              </Row>
+              <Row justify="center">
+                <Col xs={24}>
+                  <JSONInput
+                    width="100%"
+                    height="calc(100vh - 19em)"
+                    placeholder={field}
+                    onChange={handleEdit}
+                    viewOnly={!EDITABLE_FIELDS.includes(selection)}
+                    theme="light_mitsuketa_tribute"
+                    onKeyPressUpdate={false}
                   />
-                </Tooltip>
-              </Col>
-            </Row>
-            <Row justify="center">
-              <Col xs={24}>
-                <JSONInput
-                  width="100%"
-                  height="calc(100vh - 19em)"
-                  placeholder={field}
-                  onChange={handleEdit}
-                  viewOnly={!EDITABLE_FIELDS.includes(selection)}
-                  theme="light_mitsuketa_tribute"
-                  onKeyPressUpdate={false}
-                />
-              </Col>
-            </Row>
-          </Col>
-        </Row>
-      </React.Fragment>
+                </Col>
+              </Row>
+            </Col>
+          </Row>
+        </React.Fragment>
+      )}
     </DocumentTitle>
   );
 };

--- a/ui/cap-react/src/antd/schemas/Schemas.js
+++ b/ui/cap-react/src/antd/schemas/Schemas.js
@@ -1,0 +1,254 @@
+import axios from "axios";
+import React, { useEffect, useState } from "react";
+import DocumentTitle from "../partials/DocumentTitle";
+import {
+  Row,
+  Col,
+  Typography,
+  Select,
+  Button,
+  Modal,
+  notification,
+  Tooltip,
+} from "antd";
+import JsonDiff from "../../components/cms/components/SchemaWizard/JSONDiff";
+import {
+  DiffOutlined,
+  InfoCircleOutlined,
+  SaveOutlined,
+  UndoOutlined,
+} from "@ant-design/icons";
+import JSONInput from "react-json-editor-ajrm";
+
+const Schemas = ({ match }) => {
+  const EDITABLE_FIELDS = [
+    "fullname",
+    "use_deposit_as_record",
+    "deposit_mapping",
+    "record_mapping",
+    "deposit_options",
+    "record_options",
+    "config",
+  ];
+
+  const FULL_SCHEMA = "Full schema";
+
+  const { schema_name, schema_version } = match.params;
+
+  const [originalSchema, setOriginalSchema] = useState();
+  const [schema, setSchema] = useState();
+  const [field, setField] = useState();
+  const [selection, setSelection] = useState(FULL_SCHEMA);
+  const [options, setOptions] = useState();
+  const [showModal, setShowModal] = useState();
+  const [jsonError, setJsonError] = useState();
+
+  useEffect(() => {
+    axios
+      .get(`/api/jsonschemas/${schema_name}/${schema_version || ""}`)
+      .then(res => {
+        setOriginalSchema(res.data);
+        setSchema(res.data);
+        setField(res.data);
+        let opts = Object.entries(res.data)
+          .filter(
+            e =>
+              typeof e[1] === "object" && e[1] !== null && !Array.isArray(e[1])
+          )
+          .map(e => ({
+            label: e[0],
+            value: e[0],
+          }));
+        opts.unshift({ label: FULL_SCHEMA, value: "all" });
+        setOptions(opts);
+      });
+  }, []);
+
+  const handleSelectChange = (value, option) => {
+    if (value === "all") {
+      setField(schema);
+    } else {
+      setField(schema[value]);
+    }
+    setSelection(option.label);
+  };
+
+  const handleEdit = value => {
+    if (!value.error) {
+      const jsObject = value.jsObject;
+      if (selection === FULL_SCHEMA) {
+        setSchema(jsObject);
+      } else {
+        setSchema({ ...schema, [selection]: jsObject });
+      }
+      setField(jsObject);
+    }
+    setJsonError(value.error);
+  };
+
+  const handleSave = () => {
+    let schemaToSave = schema;
+    if (selection != FULL_SCHEMA) {
+      schemaToSave = { ...originalSchema, [selection]: schema[selection] };
+    }
+    axios
+      .put(`/api/jsonschemas/${schema_name}/${schema.version}`, schemaToSave)
+      .then(() => {
+        setOriginalSchema(schema);
+        notification.success({
+          message: "Schema updated",
+          description: "Changes successfully applied",
+        });
+      })
+      .catch(() =>
+        notification.error({
+          message: "Schema not updated",
+          description: "Error while saving, please try again",
+        })
+      );
+  };
+
+  const handleRevert = () => {
+    if (selection === FULL_SCHEMA) {
+      setField(originalSchema);
+      setSchema(originalSchema);
+    } else {
+      setField(originalSchema[selection]);
+      setSchema({ ...schema, [selection]: originalSchema[selection] });
+    }
+  };
+
+  return (
+    <DocumentTitle title="Schemas">
+      <React.Fragment>
+        <Modal
+          visible={showModal}
+          onCancel={() => setShowModal(false)}
+          title={`${selection} diff`}
+          width={800}
+          footer={null}
+          bodyStyle={{
+            overflowX: "scroll",
+            overflowY: "auto",
+            maxHeight: "calc(100vh - 200px)",
+          }}
+        >
+          <JsonDiff
+            left={
+              selection === FULL_SCHEMA
+                ? originalSchema
+                : originalSchema[selection]
+            }
+            right={field}
+          />
+        </Modal>
+        <Row justify="center">
+          <Col xs={22} lg={14}>
+            <Row
+              justify="space-between"
+              align="middle"
+              style={{ marginBottom: "1em" }}
+              gutter={10}
+            >
+              <Col flex="auto">
+                <Typography.Title style={{ marginBottom: "0" }}>
+                  {schema_name} {schema_version}
+                </Typography.Title>
+              </Col>
+              <Col>
+                <Tooltip
+                  placement="bottom"
+                  title="Select a field to edit it (if it is editable). 
+                  Check the diff, revert or save the changes to that field, 
+                  or go back to 'Full schema' to check the full diff, 
+                  revert or save all changes at once."
+                >
+                  <InfoCircleOutlined />
+                </Tooltip>
+              </Col>
+              <Col xs={15} md={6}>
+                {schema && (
+                  <Select
+                    style={{
+                      width: "100%",
+                    }}
+                    options={options}
+                    onChange={handleSelectChange}
+                    defaultValue="all"
+                  />
+                )}
+              </Col>
+              <Col>
+                <Tooltip
+                  placement="bottom"
+                  title={
+                    jsonError
+                      ? "Please fix the syntax errors to be able to view the diff"
+                      : selection === FULL_SCHEMA
+                        ? "View full diff"
+                        : "View field diff"
+                  }
+                >
+                  <Button
+                    icon={<DiffOutlined />}
+                    onClick={() => setShowModal(true)}
+                    disabled={jsonError}
+                  />
+                </Tooltip>
+              </Col>
+              <Col>
+                <Tooltip
+                  placement="bottom"
+                  title={
+                    selection === FULL_SCHEMA
+                      ? "Revert all unsaved changes"
+                      : "Revert unsaved changes to this field"
+                  }
+                >
+                  <Button icon={<UndoOutlined />} onClick={handleRevert} />
+                </Tooltip>
+              </Col>
+              <Col>
+                <Tooltip
+                  placement="bottom"
+                  title={
+                    selection === FULL_SCHEMA
+                      ? "Save all changes"
+                      : !EDITABLE_FIELDS.includes(selection)
+                        ? "Please select an editable field to be able to edit and save the changes"
+                        : "Save changes to this field"
+                  }
+                >
+                  <Button
+                    icon={<SaveOutlined />}
+                    type="primary"
+                    onClick={handleSave}
+                    disabled={
+                      !EDITABLE_FIELDS.includes(selection) &&
+                      selection != FULL_SCHEMA
+                    }
+                  />
+                </Tooltip>
+              </Col>
+            </Row>
+            <Row justify="center">
+              <Col xs={24}>
+                <JSONInput
+                  width="100%"
+                  height="calc(100vh - 19em)"
+                  placeholder={field}
+                  onChange={handleEdit}
+                  viewOnly={!EDITABLE_FIELDS.includes(selection)}
+                  theme="light_mitsuketa_tribute"
+                  onKeyPressUpdate={false}
+                />
+              </Col>
+            </Row>
+          </Col>
+        </Row>
+      </React.Fragment>
+    </DocumentTitle>
+  );
+};
+
+export default Schemas;

--- a/ui/cap-react/src/antd/schemas/index.js
+++ b/ui/cap-react/src/antd/schemas/index.js
@@ -1,0 +1,1 @@
+export { default } from "./Schemas";

--- a/ui/cap-react/src/antd/util/CodeEditor.js
+++ b/ui/cap-react/src/antd/util/CodeEditor.js
@@ -3,37 +3,34 @@ import { basicSetup } from "codemirror";
 import { EditorState } from "@codemirror/state";
 import { EditorView, keymap } from "@codemirror/view";
 import { json, jsonParseLinter } from "@codemirror/lang-json";
-import { indentWithTab } from "@codemirror/commands";
 import { linter, lintGutter } from "@codemirror/lint";
+import { indentWithTab } from "@codemirror/commands";
 
 const CodeEditor = ({ value, isReadOnly, handleEdit, schema }) => {
   const element = useRef(null);
 
-  useEffect(
-    () => {
-      element.current.innerHTML = "";
-      new EditorView({
-        state: EditorState.create({
-          doc: value,
-          extensions: [
-            basicSetup,
-            keymap.of([indentWithTab]),
-            json(),
-            linter(jsonParseLinter()),
-            lintGutter(),
-            EditorState.readOnly.of(isReadOnly),
-            EditorView.updateListener.of(update => {
-              if (update.docChanged) {
-                handleEdit(update.state.doc.toString());
-              }
-            }),
-          ],
-        }),
-        parent: element.current,
-      });
-    },
-    [value, schema]
-  );
+  useEffect(() => {
+    element.current.innerHTML = "";
+    new EditorView({
+      state: EditorState.create({
+        doc: value,
+        extensions: [
+          basicSetup,
+          keymap.of([indentWithTab]),
+          json(),
+          linter(jsonParseLinter()),
+          lintGutter(),
+          EditorState.readOnly.of(isReadOnly),
+          EditorView.updateListener.of((update) => {
+            if (update.docChanged) {
+              handleEdit(update.state.doc.toString());
+            }
+          }),
+        ],
+      }),
+      parent: element.current,
+    });
+  }, [value, schema]);
 
   return <div ref={element} />;
 };

--- a/ui/cap-react/src/antd/util/CodeEditor.js
+++ b/ui/cap-react/src/antd/util/CodeEditor.js
@@ -1,0 +1,41 @@
+import React, { useEffect, useRef } from "react";
+import { basicSetup } from "codemirror";
+import { EditorState } from "@codemirror/state";
+import { EditorView, keymap } from "@codemirror/view";
+import { json, jsonParseLinter } from "@codemirror/lang-json";
+import { indentWithTab } from "@codemirror/commands";
+import { linter, lintGutter } from "@codemirror/lint";
+
+const CodeEditor = ({ value, isReadOnly, handleEdit, schema }) => {
+  const element = useRef(null);
+
+  useEffect(
+    () => {
+      element.current.innerHTML = "";
+      new EditorView({
+        state: EditorState.create({
+          doc: value,
+          extensions: [
+            basicSetup,
+            keymap.of([indentWithTab]),
+            json(),
+            linter(jsonParseLinter()),
+            lintGutter(),
+            EditorState.readOnly.of(isReadOnly),
+            EditorView.updateListener.of(update => {
+              if (update.docChanged) {
+                handleEdit(update.state.doc.toString());
+              }
+            }),
+          ],
+        }),
+        parent: element.current,
+      });
+    },
+    [value, schema]
+  );
+
+  return <div ref={element} />;
+};
+
+export default CodeEditor;

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -11074,15 +11074,6 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
-husky@0.14.3:
-  version "0.14.3"
-  resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"
-  integrity sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==
-  dependencies:
-    is-ci "^1.0.10"
-    normalize-path "^1.0.0"
-    strip-indent "^2.0.0"
-
 hyphenate-style-name@^1.0.0, hyphenate-style-name@^1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/hyphenate-style-name/-/hyphenate-style-name-1.0.3.tgz#097bb7fa0b8f1a9cf0bd5c734cf95899981a9b48"
@@ -14774,11 +14765,6 @@ normalize-package-data@^2.3.2, normalize-package-data@^2.3.4:
     resolve "^1.10.0"
     semver "2 || 3 || 4 || 5"
     validate-npm-package-license "^3.0.1"
-
-normalize-path@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-1.0.0.tgz#32d0e472f91ff345701c15a8311018d3b0a90379"
-  integrity sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=
 
 normalize-path@^2.0.0, normalize-path@^2.0.1, normalize-path@^2.1.1:
   version "2.1.1"
@@ -20479,11 +20465,6 @@ strip-indent@^1.0.1:
   integrity sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=
   dependencies:
     get-stdin "^4.0.1"
-
-strip-indent@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/strip-indent/-/strip-indent-2.0.0.tgz#5ef8db295d01e6ed6cbf7aab96998d7822527b68"
-  integrity sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=
 
 strip-indent@^3.0.0:
   version "3.0.0"

--- a/ui/yarn.lock
+++ b/ui/yarn.lock
@@ -1119,6 +1119,87 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
+"@codemirror/autocomplete@^6.0.0":
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/autocomplete/-/autocomplete-6.3.0.tgz#217e16bb6ce63374ec7b9d2a01d007ba53ff0aff"
+  integrity sha512-4jEvh3AjJZTDKazd10J6ZsCIqaYxDMCeua5ouQxY8hlFIml+nr7le0SgBhT3SIytFBmdzPK3AUhXGuW3T79nVg==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+
+"@codemirror/commands@6.1.2", "@codemirror/commands@^6.0.0":
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/commands/-/commands-6.1.2.tgz#84fb7d170047c3aeb7b0047ace59510bb19208de"
+  integrity sha512-sO3jdX1s0pam6lIdeSJLMN3DQ6mPEbM4yLvyKkdqtmd/UDwhXA5+AwFJ89rRXm6vTeOXBsE5cAmlos/t7MJdgg==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+
+"@codemirror/lang-json@6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/lang-json/-/lang-json-6.0.1.tgz#0a0be701a5619c4b0f8991f9b5e95fe33f462330"
+  integrity sha512-+T1flHdgpqDDlJZ2Lkil/rLiRy684WMLc74xUnjJH48GQdfJo/pudlTRreZmKwzP8/tGdKf83wlbAdOCzlJOGQ==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
+    "@lezer/json" "^1.0.0"
+
+"@codemirror/language@^6.0.0":
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/@codemirror/language/-/language-6.3.1.tgz#1d61f33aa5de9aa74a713ee1f5ce600adc74df6b"
+  integrity sha512-MK+G1QKaGfSEUg9YEFaBkMBI6j1ge4VMBPZv9fDYotw7w695c42x5Ba1mmwBkesYnzYFBfte6Hh9TDcKa6xORQ==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    "@lezer/common" "^1.0.0"
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+    style-mod "^4.0.0"
+
+"@codemirror/lint@6.1.0":
+  version "6.1.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/lint/-/lint-6.1.0.tgz#f006142d3a580fdb8ffc2faa3361b2232c08e079"
+  integrity sha512-mdvDQrjRmYPvQ3WrzF6Ewaao+NWERYtpthJvoQ3tK3t/44Ynhk8ZGjTSL9jMEv8CgSMogmt75X8ceOZRDSXHtQ==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    crelt "^1.0.5"
+
+"@codemirror/lint@^6.0.0":
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/@codemirror/lint/-/lint-6.0.0.tgz#a249b021ac9933b94fe312d994d220f0ef11a157"
+  integrity sha512-nUUXcJW1Xp54kNs+a1ToPLK8MadO0rMTnJB8Zk4Z8gBdrN0kqV7uvUraU/T2yqg+grDNR38Vmy/MrhQN/RgwiA==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    crelt "^1.0.5"
+
+"@codemirror/search@^6.0.0":
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/search/-/search-6.2.2.tgz#278ac204bd19a038271595ce060ad32c13eb70a6"
+  integrity sha512-2pWY599zXk+lSoJ2iv9EuTO4gB7lhgBPLPwFb/zTbimFH4NmZSaKzJSV51okjABZ7/Rj0DYy5klWbIgaJh2LoQ==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+    crelt "^1.0.5"
+
+"@codemirror/state@6.1.3", "@codemirror/state@^6.0.0":
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/@codemirror/state/-/state-6.1.3.tgz#39bf545c589f51b6978716d188d34f7d7c483350"
+  integrity sha512-0Rn7vadZ6EgHaKdIOwyhBWLdPDh1JM5USYqXjxwrvpmTKWu4wQ77twgAYEg1MU282XcrnV4ZqFf+00bu6UPCyg==
+
+"@codemirror/view@6.4.2", "@codemirror/view@^6.0.0":
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/@codemirror/view/-/view-6.4.2.tgz#402a70830598b8ecb87a755ab03433899ce020f8"
+  integrity sha512-pKqUTc41sKxNrcqxLm6wV25J2tggSG3tybV+t/nfZNwA16S3vlBFsFLLy18dGOV1APajAl2ehXb7ZxJOayux4Q==
+  dependencies:
+    "@codemirror/state" "^6.0.0"
+    style-mod "^4.0.0"
+    w3c-keyname "^2.2.4"
+
 "@csstools/convert-colors@^1.4.0":
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
@@ -1521,6 +1602,33 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^15.0.0"
     chalk "^3.0.0"
+
+"@lezer/common@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@lezer/common/-/common-1.0.1.tgz#d014fda6d582c24336fadf2715e76f02f73c8908"
+  integrity sha512-8TR5++Q/F//tpDsLd5zkrvEX5xxeemafEaek7mUp7Y+bI8cKQXdSqhzTOBaOogETcMOVr0pT3BBPXp13477ciw==
+
+"@lezer/highlight@^1.0.0":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@lezer/highlight/-/highlight-1.1.2.tgz#60cd6c2a0a2cf753b8a026b04feeb0ea8df326ea"
+  integrity sha512-CAun1WR1glxG9ZdOokTZwXbcwB7PXkIEyZRUMFBVwSrhTcogWq634/ByNImrkUnQhjju6xsIaOBIxvcRJtplXQ==
+  dependencies:
+    "@lezer/common" "^1.0.0"
+
+"@lezer/json@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@lezer/json/-/json-1.0.0.tgz#848ad9c2c3e812518eb02897edd5a7f649e9c160"
+  integrity sha512-zbAuUY09RBzCoCA3lJ1+ypKw5WSNvLqGMtasdW6HvVOqZoCpPr8eWrsGnOVWGKGn8Rh21FnrKRVlJXrGAVUqRw==
+  dependencies:
+    "@lezer/highlight" "^1.0.0"
+    "@lezer/lr" "^1.0.0"
+
+"@lezer/lr@^1.0.0":
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/@lezer/lr/-/lr-1.2.4.tgz#380b8586c5578ca5d1187afd2284d51af103951e"
+  integrity sha512-L/52/oMJBFXXx8qBYF4UgktLP2geQ/qn5Fd8+5L/mqlLLCB9+qdKktFAtejd9FdFMaFx6lrP5rmLz4sN3Kplcg==
+  dependencies:
+    "@lezer/common" "^1.0.0"
 
 "@mattiasbuelens/web-streams-polyfill@^0.2.0":
   version "0.2.1"
@@ -6597,6 +6705,19 @@ code-point-at@^1.0.0:
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
   integrity sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
 
+codemirror@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-6.0.1.tgz#62b91142d45904547ee3e0e0e4c1a79158035a29"
+  integrity sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==
+  dependencies:
+    "@codemirror/autocomplete" "^6.0.0"
+    "@codemirror/commands" "^6.0.0"
+    "@codemirror/language" "^6.0.0"
+    "@codemirror/lint" "^6.0.0"
+    "@codemirror/search" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+
 cogo-toast@4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/cogo-toast/-/cogo-toast-4.1.1.tgz#623f05eab713f45f1406851e3dab83e7c6bc7fb0"
@@ -7140,6 +7261,11 @@ create-react-context@0.3.0, create-react-context@^0.3.0:
   dependencies:
     gud "^1.0.0"
     warning "^4.0.3"
+
+crelt@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/crelt/-/crelt-1.0.5.tgz#57c0d52af8c859e354bace1883eb2e1eb182bb94"
+  integrity sha512-+BO9wPPi+DWTDcNYhr/W90myha8ptzftZT+LwcmUbbok0rcP/fequmFYCw8NMoH7pkAZQzU78b3kYrlua5a9eA==
 
 cross-spawn@6.0.5, cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
@@ -18249,10 +18375,19 @@ react@^15.3.0:
     object-assign "^4.1.0"
     prop-types "^15.5.10"
 
-react@^16.13.1, react@^16.6.0, react@^16.8.3:
+react@^16.13.1, react@^16.8.3:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
   integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+
+react@^16.14.0:
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
+  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
@@ -20391,6 +20526,11 @@ style-loader@^1.0.0:
     loader-utils "^2.0.0"
     schema-utils "^2.6.6"
 
+style-mod@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/style-mod/-/style-mod-4.0.0.tgz#97e7c2d68b592975f2ca7a63d0dd6fcacfe35a01"
+  integrity sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==
+
 styled-components@4.4.1:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.4.1.tgz#e0631e889f01db67df4de576fedaca463f05c2f2"
@@ -21595,6 +21735,11 @@ w3c-hr-time@^1.0.1:
   integrity sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==
   dependencies:
     browser-process-hrtime "^1.0.0"
+
+w3c-keyname@^2.2.4:
+  version "2.2.6"
+  resolved "https://registry.yarnpkg.com/w3c-keyname/-/w3c-keyname-2.2.6.tgz#8412046116bc16c5d73d4e612053ea10a189c85f"
+  integrity sha512-f+fciywl1SJEniZHD6H+kUO8gOnwIr7f4ijKA6+ZvJFjeGi1r4PDLl53Ayud9O/rk64RqgoQine0feoeOU0kXg==
 
 w3c-xmlserializer@^1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Closes #2669 adding a page to display schemas (e.g. `/schemas/cms-analysis[/0.0.1]`) and edit them, only allowing edition of certain allowed fields. It also lets you check the diff and revert the current changes before saving.