### PR TITLE
ui: admin layout changes

### DIFF
--- a/ui/cap-react/src/antd/App/App.less
+++ b/ui/cap-react/src/antd/App/App.less
@@ -34,3 +34,7 @@
 .scrollableTabs .ant-tabs-content-holder {
   overflow-y: scroll;
 }
+
+.ant-descriptions-view table {
+  margin-bottom: 0;
+}

--- a/ui/cap-react/src/antd/App/App.less
+++ b/ui/cap-react/src/antd/App/App.less
@@ -27,7 +27,10 @@
   height: 100%;
 }
 
-
 .hoverPointer:hover{
   cursor: pointer;
+}
+
+.scrollableTabs .ant-tabs-content-holder {
+  overflow-y: scroll;
 }

--- a/ui/cap-react/src/antd/admin/components/Customize.js
+++ b/ui/cap-react/src/antd/admin/components/Customize.js
@@ -14,6 +14,7 @@ const Customize = ({
   onUiSchemaChange,
   path,
   _path,
+  _uiPath,
 }) => {
   const [justify, setJustify] = useState(() => "start");
   const [size, setSize] = useState("xlarge");
@@ -85,6 +86,7 @@ const Customize = ({
             onChange={_onUiSchemaChange}
             optionsSchemaObject="optionsUiSchema"
             optionsUiSchemaObject="optionsUiSchemaUiSchema"
+            key={_uiPath}
           />
         ) : (
           <Space

--- a/ui/cap-react/src/antd/admin/components/Customize.js
+++ b/ui/cap-react/src/antd/admin/components/Customize.js
@@ -1,24 +1,41 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
 import PropertyKeyEditorForm from "./PropKeyEditorForm";
 
 import { Radio, Space, Tabs, Typography } from "antd";
 import _debounce from "lodash/debounce";
+import { SIZE_OPTIONS } from "../utils";
 
-const SIZE_OPTIONS = ["small", "large", "xlarge", "xxlarge", "full"];
-const ALIGN_OPTIONS = ["center", "start", "end"];
+const JUSTIFY_OPTIONS = ["start", "center", "end"];
 
-const Customize = props => {
+const Customize = ({
+  schema,
+  uiSchema,
+  onSchemaChange,
+  onUiSchemaChange,
+  path,
+  _path,
+}) => {
+  const [justify, setJustify] = useState(() => "start");
+  const [size, setSize] = useState("xlarge");
+
+  useEffect(
+    () => {
+      if (uiSchema.toJS().hasOwnProperty("ui:options")) {
+        setSize(uiSchema.toJS()["ui:options"].size);
+        setJustify(uiSchema.toJS()["ui:options"].justify);
+      }
+    },
+    [uiSchema]
+  );
+
   const _onSchemaChange = data => {
-    props.onSchemaChange(props.path.get("path").toJS(), data.formData);
+    onSchemaChange(path.get("path").toJS(), data.formData);
   };
   const _onUiSchemaChange = data => {
-    props.onUiSchemaChange(props.path.get("uiPath").toJS(), data.formData);
+    onUiSchemaChange(path.get("uiPath").toJS(), data.formData);
   };
   const sizeChange = newSize => {
-    if (SIZE_OPTIONS.indexOf(newSize) < 0) return;
-
-    let { uiSchema } = props;
     uiSchema = uiSchema ? uiSchema.toJS() : {};
 
     let { "ui:options": uiOptions = {}, ...rest } = uiSchema;
@@ -27,16 +44,13 @@ const Customize = props => {
     size = newSize;
     let _uiOptions = { size, ...restUIOptions };
 
-    props.onUiSchemaChange(props.path.get("uiPath").toJS(), {
+    onUiSchemaChange(path.get("uiPath").toJS(), {
       ...rest,
       "ui:options": _uiOptions,
     });
   };
 
   const alignChange = newAlign => {
-    if (["center", "start", "end"].indexOf(newAlign) < 0) return;
-
-    let { uiSchema } = props;
     uiSchema = uiSchema ? uiSchema.toJS() : {};
 
     let { "ui:options": uiOptions = {}, ...rest } = uiSchema;
@@ -45,7 +59,7 @@ const Customize = props => {
     justify = newAlign;
     let _uiOptions = { justify, ...restUIOptions };
 
-    props.onUiSchemaChange(props.path.get("uiPath").toJS(), {
+    onUiSchemaChange(path.get("uiPath").toJS(), {
       ...rest,
       "ui:options": _uiOptions,
     });
@@ -55,33 +69,37 @@ const Customize = props => {
     <Tabs centered style={{ height: "100%", overflow: "scroll" }}>
       <Tabs.TabPane tab="Schema Settings" key="1">
         <PropertyKeyEditorForm
-          schema={props.schema && props.schema.toJS()}
-          uiSchema={props.uiSchema && props.uiSchema.toJS()}
-          formData={props.schema && props.schema.toJS()}
+          schema={schema && schema.toJS()}
+          uiSchema={uiSchema && uiSchema.toJS()}
+          formData={schema && schema.toJS()}
           onChange={_debounce(_onSchemaChange, 500)}
           optionsSchemaObject="optionsSchema"
           optionsUiSchemaObject="optionsSchemaUiSchema"
         />
       </Tabs.TabPane>
       <Tabs.TabPane tab="UI Schema Settings" key="2">
-        {props._path.size != 0 ? (
+        {_path.size != 0 ? (
           <PropertyKeyEditorForm
-            schema={props.schema && props.schema.toJS()}
-            uiSchema={props.uiSchema && props.uiSchema.toJS()}
-            formData={props.uiSchema && props.uiSchema.toJS()}
+            schema={schema && schema.toJS()}
+            uiSchema={uiSchema && uiSchema.toJS()}
+            formData={uiSchema && uiSchema.toJS()}
             onChange={_debounce(_onUiSchemaChange, 500)}
             optionsSchemaObject="optionsUiSchema"
             optionsUiSchemaObject="optionsUiSchemaUiSchema"
           />
         ) : (
-          <Space direction="vertical" style={{ padding: "0 12px" }}>
+          <Space
+            direction="vertical"
+            style={{ padding: "0 12px", width: "100%" }}
+          >
             <Typography.Text>Size Options</Typography.Text>
             <Radio.Group
               size="small"
               onChange={e => sizeChange(e.target.value)}
+              value={size}
               style={{ paddingBottom: "15px" }}
             >
-              {SIZE_OPTIONS.map(size => (
+              {Object.keys(SIZE_OPTIONS).map(size => (
                 <Radio.Button value={size}>{size}</Radio.Button>
               ))}
             </Radio.Group>
@@ -89,8 +107,9 @@ const Customize = props => {
             <Radio.Group
               size="small"
               onChange={e => alignChange(e.target.value)}
+              value={justify}
             >
-              {ALIGN_OPTIONS.map(justify => (
+              {JUSTIFY_OPTIONS.map(justify => (
                 <Radio.Button value={justify}>{justify}</Radio.Button>
               ))}
             </Radio.Group>
@@ -104,9 +123,9 @@ const Customize = props => {
 Customize.propTypes = {
   schema: PropTypes.object,
   uiSchema: PropTypes.object,
-  path: PropTypes.object,
   onSchemaChange: PropTypes.func,
   onUiSchemaChange: PropTypes.func,
+  path: PropTypes.object,
   _path: PropTypes.object,
 };
 

--- a/ui/cap-react/src/antd/admin/components/Customize.js
+++ b/ui/cap-react/src/antd/admin/components/Customize.js
@@ -3,7 +3,6 @@ import PropTypes from "prop-types";
 import PropertyKeyEditorForm from "./PropKeyEditorForm";
 
 import { Radio, Space, Tabs, Typography } from "antd";
-import _debounce from "lodash/debounce";
 import { SIZE_OPTIONS } from "../utils";
 
 const JUSTIFY_OPTIONS = ["start", "center", "end"];
@@ -21,7 +20,7 @@ const Customize = ({
 
   useEffect(
     () => {
-      if (uiSchema.toJS().hasOwnProperty("ui:options")) {
+      if (uiSchema && uiSchema.toJS().hasOwnProperty("ui:options")) {
         setSize(uiSchema.toJS()["ui:options"].size);
         setJustify(uiSchema.toJS()["ui:options"].justify);
       }
@@ -66,13 +65,13 @@ const Customize = ({
   };
 
   return (
-    <Tabs className="scrollableTabs" centered>
+    <Tabs className="scrollableTabs" centered style={{ flex: 1 }}>
       <Tabs.TabPane tab="Schema Settings" key="1">
         <PropertyKeyEditorForm
           schema={schema && schema.toJS()}
           uiSchema={uiSchema && uiSchema.toJS()}
           formData={schema && schema.toJS()}
-          onChange={_debounce(_onSchemaChange, 500)}
+          onChange={_onSchemaChange}
           optionsSchemaObject="optionsSchema"
           optionsUiSchemaObject="optionsSchemaUiSchema"
         />
@@ -83,7 +82,7 @@ const Customize = ({
             schema={schema && schema.toJS()}
             uiSchema={uiSchema && uiSchema.toJS()}
             formData={uiSchema && uiSchema.toJS()}
-            onChange={_debounce(_onUiSchemaChange, 500)}
+            onChange={_onUiSchemaChange}
             optionsSchemaObject="optionsUiSchema"
             optionsUiSchemaObject="optionsUiSchemaUiSchema"
           />

--- a/ui/cap-react/src/antd/admin/components/Customize.js
+++ b/ui/cap-react/src/antd/admin/components/Customize.js
@@ -66,7 +66,7 @@ const Customize = ({
   };
 
   return (
-    <Tabs centered style={{ height: "100%", overflow: "scroll" }}>
+    <Tabs className="scrollableTabs" centered>
       <Tabs.TabPane tab="Schema Settings" key="1">
         <PropertyKeyEditorForm
           schema={schema && schema.toJS()}

--- a/ui/cap-react/src/antd/admin/components/Customize.js
+++ b/ui/cap-react/src/antd/admin/components/Customize.js
@@ -2,7 +2,7 @@ import React from "react";
 import PropTypes from "prop-types";
 import PropertyKeyEditorForm from "./PropKeyEditorForm";
 
-import { Card, Space, Tag, Typography } from "antd";
+import { Radio, Space, Tabs, Typography } from "antd";
 import _debounce from "lodash/debounce";
 
 const SIZE_OPTIONS = ["small", "large", "xlarge", "xxlarge", "full"];
@@ -52,69 +52,52 @@ const Customize = props => {
   };
 
   return (
-    <Space direction="vertical" style={{ width: "100%" }}>
-      <PropertyKeyEditorForm
-        schema={props.schema && props.schema.toJS()}
-        uiSchema={props.uiSchema && props.uiSchema.toJS()}
-        formData={props.schema && props.schema.toJS()}
-        onChange={_debounce(_onSchemaChange, 500)}
-        optionsSchemaObject="optionsSchema"
-        optionsUiSchemaObject="optionsSchemaUiSchema"
-        title="Schema Settings"
-      />
-
-      <PropertyKeyEditorForm
-        schema={props.schema && props.schema.toJS()}
-        uiSchema={props.uiSchema && props.uiSchema.toJS()}
-        formData={props.uiSchema && props.uiSchema.toJS()}
-        onChange={_debounce(_onUiSchemaChange, 500)}
-        optionsSchemaObject="optionsUiSchema"
-        optionsUiSchemaObject="optionsUiSchemaUiSchema"
-        title="UI Schema Settings"
-      />
-
-      {props._path.size == 0 && (
-        <Card title="UI Options">
-          <Space direction="vertical" size="large" style={{ width: "100%" }}>
-            <Space>
-              <Typography.Text>Size Options</Typography.Text>
+    <Tabs centered style={{ height: "100%", overflow: "scroll" }}>
+      <Tabs.TabPane tab="Schema Settings" key="1">
+        <PropertyKeyEditorForm
+          schema={props.schema && props.schema.toJS()}
+          uiSchema={props.uiSchema && props.uiSchema.toJS()}
+          formData={props.schema && props.schema.toJS()}
+          onChange={_debounce(_onSchemaChange, 500)}
+          optionsSchemaObject="optionsSchema"
+          optionsUiSchemaObject="optionsSchemaUiSchema"
+        />
+      </Tabs.TabPane>
+      <Tabs.TabPane tab="UI Schema Settings" key="2">
+        {props._path.size != 0 ? (
+          <PropertyKeyEditorForm
+            schema={props.schema && props.schema.toJS()}
+            uiSchema={props.uiSchema && props.uiSchema.toJS()}
+            formData={props.uiSchema && props.uiSchema.toJS()}
+            onChange={_debounce(_onUiSchemaChange, 500)}
+            optionsSchemaObject="optionsUiSchema"
+            optionsUiSchemaObject="optionsUiSchemaUiSchema"
+          />
+        ) : (
+          <Space direction="vertical" style={{ padding: "0 12px" }}>
+            <Typography.Text>Size Options</Typography.Text>
+            <Radio.Group
+              size="small"
+              onChange={e => sizeChange(e.target.value)}
+              style={{ paddingBottom: "15px" }}
+            >
               {SIZE_OPTIONS.map(size => (
-                <Tag
-                  onClick={() => sizeChange(size)}
-                  key={size}
-                  color={
-                    props.uiSchema &&
-                    props.uiSchema.toJS()["ui:options"] &&
-                    props.uiSchema.toJS()["ui:options"].size == size &&
-                    "geekblue"
-                  }
-                >
-                  {size}
-                </Tag>
+                <Radio.Button value={size}>{size}</Radio.Button>
               ))}
-            </Space>
-            <Space>
-              <Typography.Text>Align Options</Typography.Text>
-
+            </Radio.Group>
+            <Typography.Text>Align Options</Typography.Text>
+            <Radio.Group
+              size="small"
+              onChange={e => alignChange(e.target.value)}
+            >
               {ALIGN_OPTIONS.map(justify => (
-                <Tag
-                  onClick={() => alignChange(justify)}
-                  key={justify}
-                  color={
-                    props.uiSchema &&
-                    props.uiSchema.toJS()["ui:options"] &&
-                    props.uiSchema.toJS()["ui:options"].justify == justify &&
-                    "geekblue"
-                  }
-                >
-                  {justify}
-                </Tag>
+                <Radio.Button value={justify}>{justify}</Radio.Button>
               ))}
-            </Space>
+            </Radio.Group>
           </Space>
-        </Card>
-      )}
-    </Space>
+        )}
+      </Tabs.TabPane>
+    </Tabs>
   );
 };
 

--- a/ui/cap-react/src/antd/admin/components/FormPreview.js
+++ b/ui/cap-react/src/antd/admin/components/FormPreview.js
@@ -10,6 +10,7 @@ const FormPreview = ({ schema, uiSchema }) => {
     return (
       <Row justify="center" align="middle" style={{ height: "100%" }}>
         <Empty
+          image={Empty.PRESENTED_IMAGE_SIMPLE}
           description={
             <Space direction="vertical">
               <Typography.Title level={5}>Your form is empty</Typography.Title>

--- a/ui/cap-react/src/antd/admin/components/FormPreview.js
+++ b/ui/cap-react/src/antd/admin/components/FormPreview.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import Form from "../../forms/Form";
 import { transformSchema } from "../../partials/Utils/schema";
 import { shoudDisplayGuideLinePopUp } from "../utils";
-import { Row, Empty, Space, Typography } from "antd";
+import { Row, Empty, Space, Typography, Col } from "antd";
 
 const FormPreview = ({ schema, uiSchema }) => {
   if (shoudDisplayGuideLinePopUp(schema))
@@ -22,12 +22,16 @@ const FormPreview = ({ schema, uiSchema }) => {
       </Row>
     );
   return (
-    <Form
-      schema={transformSchema(schema.toJS())}
-      uiSchema={uiSchema.toJS()}
-      formData={{}}
-      onChange={() => {}}
-    />
+    <Row justify="center">
+      <Col xs={22} sm={20}>
+        <Form
+          schema={transformSchema(schema.toJS())}
+          uiSchema={uiSchema.toJS()}
+          formData={{}}
+          onChange={() => {}}
+        />
+      </Col>
+    </Row>
   );
 };
 

--- a/ui/cap-react/src/antd/admin/components/PropKeyEditorForm.js
+++ b/ui/cap-react/src/antd/admin/components/PropKeyEditorForm.js
@@ -1,9 +1,8 @@
-import React, { useState } from "react";
+import React from "react";
 import PropTypes from "prop-types";
 import Form from "../../forms/Form";
 import fieldTypes from "../utils/fieldTypes";
-import { Button, Card, Row } from "antd";
-import { UpOutlined } from "@ant-design/icons";
+import widgets from "../formComponents/widgets";
 
 const PropertyKeyEditorForm = ({
   uiSchema = {},
@@ -12,10 +11,7 @@ const PropertyKeyEditorForm = ({
   onChange = null,
   optionsSchemaObject,
   optionsUiSchemaObject,
-  title = "",
 }) => {
-  const [display, setDisplay] = useState(true);
-
   let type;
 
   // in case we can not define the type of the element from the uiSchema,
@@ -51,23 +47,13 @@ const PropertyKeyEditorForm = ({
   };
 
   return (
-    <Card
-      title={title}
-      extra={display && <UpOutlined onClick={() => setDisplay(false)} />}
-    >
-      {display ? (
-        <Form
-          schema={objs[type][`${optionsSchemaObject}`] || {}}
-          uiSchema={objs[type][`${optionsUiSchemaObject}`] || {}}
-          formData={formData}
-          onChange={onChange}
-        />
-      ) : (
-        <Row justify="center">
-          <Button onClick={() => setDisplay(true)}>Show more</Button>
-        </Row>
-      )}
-    </Card>
+    <Form
+      schema={objs[type][`${optionsSchemaObject}`] || {}}
+      uiSchema={objs[type][`${optionsUiSchemaObject}`] || {}}
+      widgets={widgets}
+      formData={formData}
+      onChange={onChange}
+    />
   );
 };
 
@@ -78,7 +64,6 @@ PropertyKeyEditorForm.propTypes = {
   onChange: PropTypes.func,
   optionsSchemaObject: PropTypes.object,
   optionsUiSchemaObject: PropTypes.object,
-  title: PropTypes.string,
 };
 
 export default PropertyKeyEditorForm;

--- a/ui/cap-react/src/antd/admin/components/PropertyEditor.js
+++ b/ui/cap-react/src/antd/admin/components/PropertyEditor.js
@@ -85,7 +85,7 @@ const PropertyEditor = ({ path, renameId, enableCreateMode, deleteByPath }) => {
         <Col xs={22} style={{ paddingBottom: "20px", textAlign: "center" }}>
           {renderPath(path)}
         </Col>
-        <Col xs={22}>
+        <Col xs={18}>
           <Typography.Title
             level={5}
             editable={{

--- a/ui/cap-react/src/antd/admin/components/PropertyEditor.js
+++ b/ui/cap-react/src/antd/admin/components/PropertyEditor.js
@@ -60,7 +60,7 @@ const PropertyEditor = ({ path, renameId, enableCreateMode, deleteByPath }) => {
   );
 
   return (
-    <div>
+    <div style={{ display: "flex", flexDirection: "column" }}>
       <PageHeader
         onBack={enableCreateMode}
         title="Show Fields"
@@ -82,7 +82,7 @@ const PropertyEditor = ({ path, renameId, enableCreateMode, deleteByPath }) => {
         }
       />
       <Row justify="center">
-        <Col xs={22} style={{ paddingBottom: "20px" }}>
+        <Col xs={22} style={{ paddingBottom: "20px", textAlign: "center" }}>
           {renderPath(path)}
         </Col>
         <Col xs={22}>

--- a/ui/cap-react/src/antd/admin/components/SchemaPreview.js
+++ b/ui/cap-react/src/antd/admin/components/SchemaPreview.js
@@ -1,20 +1,26 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Col, Divider, Space, Typography } from "antd";
+import { Button, Col, Row, Typography } from "antd";
 import SchemaTree from "../containers/SchemaTree";
 import { SettingOutlined } from "@ant-design/icons";
 
 const SchemaPreview = ({ schema, selectProperty }) => {
   return (
-    <Col span={24} style={{ height: "90%" }}>
-      <Divider orientation="left">
-        <Space onClick={() => selectProperty({ schema: [], uiSchema: [] })}>
-          <SettingOutlined />
-          <Typography.Title style={{ margin: 0 }} level={5}>
-            {(schema && schema.get("title")) || "Root"}
-          </Typography.Title>
-        </Space>
-      </Divider>
+    <Col span={24} style={{ height: "90%", marginTop: "16px" }}>
+      <Row
+        justify="space-between"
+        style={{ paddingLeft: "10px", paddingRight: "10px" }}
+      >
+        <Typography.Title level={5}>
+          {(schema && schema.get("title")) || "Root"}
+        </Typography.Title>
+        <Button
+          type="link"
+          shape="circle"
+          icon={<SettingOutlined />}
+          onClick={() => selectProperty({ schema: [], uiSchema: [] })}
+        />
+      </Row>
       <SchemaTree key="schemaTree" />
     </Col>
   );

--- a/ui/cap-react/src/antd/admin/components/SchemaWizard.js
+++ b/ui/cap-react/src/antd/admin/components/SchemaWizard.js
@@ -18,10 +18,7 @@ const SchemaWizard = ({ field, loader }) => {
   return (
     <DndProvider backend={HTML5Backend}>
       <Row style={{ height: "100%" }} gutter={[16, 16]}>
-        <Col
-          span={5}
-          style={{ overflowX: "hidden", height: "100%", padding: "15px" }}
-        >
+        <Col span={5} style={{ overflowX: "hidden", height: "100%" }}>
           {field ? <PropertyEditor /> : <SelectFieldType />}
         </Col>
         <Col
@@ -43,7 +40,7 @@ const SchemaWizard = ({ field, loader }) => {
 
 SchemaWizard.propTypes = {
   loader: PropTypes.bool,
-  field: PropTypes.object
+  field: PropTypes.object,
 };
 
 export default SchemaWizard;

--- a/ui/cap-react/src/antd/admin/components/SchemaWizard.js
+++ b/ui/cap-react/src/antd/admin/components/SchemaWizard.js
@@ -29,7 +29,12 @@ const SchemaWizard = ({ field, loader }) => {
         </Col>
         <Col
           span={14}
-          style={{ overflowX: "hidden", height: "100%", padding: "15px" }}
+          style={{
+            overflowX: "hidden",
+            height: "100%",
+            padding: "15px",
+            borderLeft: "1px dotted lightgray",
+          }}
         >
           <FormPreview />
         </Col>

--- a/ui/cap-react/src/antd/admin/components/SchemaWizard.js
+++ b/ui/cap-react/src/antd/admin/components/SchemaWizard.js
@@ -18,7 +18,14 @@ const SchemaWizard = ({ field, loader }) => {
   return (
     <DndProvider backend={HTML5Backend}>
       <Row style={{ height: "100%" }} gutter={[16, 16]}>
-        <Col span={5} style={{ overflowX: "hidden", height: "100%" }}>
+        <Col
+          span={5}
+          style={{
+            overflowX: "hidden",
+            height: "100%",
+            display: "flex",
+          }}
+        >
           {field ? <PropertyEditor /> : <SelectFieldType />}
         </Col>
         <Col

--- a/ui/cap-react/src/antd/admin/components/SelectFieldType.js
+++ b/ui/cap-react/src/antd/admin/components/SelectFieldType.js
@@ -5,7 +5,7 @@ import Draggable from "./Draggable";
 
 const SelectFieldType = () => {
   return (
-    <Space direction="vertical" size="large">
+    <Space direction="vertical" size="large" style={{ padding: "0px 12px" }}>
       {Object.entries(fields).map(([key, type]) => (
         <div key={key}>
           <Divider orientation="left">

--- a/ui/cap-react/src/antd/admin/formComponents/widgets/SliderWidget.js
+++ b/ui/cap-react/src/antd/admin/formComponents/widgets/SliderWidget.js
@@ -1,0 +1,36 @@
+import React, { useState } from "react";
+import PropTypes from "prop-types";
+import { Slider } from "antd";
+
+const SliderWidget = ({ schema, onChange }) => {
+  const { defaultValue, values, labels } = schema;
+
+  const [marks] = useState(() => {
+    const m = {};
+    labels.forEach((l, i) => (m[i] = l));
+    return m;
+  });
+
+  const handleChange = event => {
+    onChange(values[event]);
+  };
+
+  return (
+    <Slider
+      marks={marks}
+      defaultValue={defaultValue}
+      step={null}
+      min={0}
+      max={Object.keys(marks).length - 1}
+      tooltipVisible={false}
+      onChange={handleChange}
+    />
+  );
+};
+
+SliderWidget.propTypes = {
+  schema: PropTypes.object,
+  onChange: PropTypes.func,
+};
+
+export default SliderWidget;

--- a/ui/cap-react/src/antd/admin/formComponents/widgets/SliderWidget.js
+++ b/ui/cap-react/src/antd/admin/formComponents/widgets/SliderWidget.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import PropTypes from "prop-types";
 import { Slider } from "antd";
 
-const SliderWidget = ({ schema, onChange }) => {
+const SliderWidget = ({ schema, onChange, value }) => {
   const { defaultValue, values, labels } = schema;
 
   const [marks] = useState(() => {
@@ -18,7 +18,9 @@ const SliderWidget = ({ schema, onChange }) => {
   return (
     <Slider
       marks={marks}
-      defaultValue={defaultValue}
+      defaultValue={
+        values.indexOf(value) >= 0 ? values.indexOf(value) : defaultValue
+      }
       step={null}
       min={0}
       max={Object.keys(marks).length - 1}
@@ -31,6 +33,7 @@ const SliderWidget = ({ schema, onChange }) => {
 SliderWidget.propTypes = {
   schema: PropTypes.object,
   onChange: PropTypes.func,
+  value: PropTypes.number,
 };
 
 export default SliderWidget;

--- a/ui/cap-react/src/antd/admin/formComponents/widgets/index.js
+++ b/ui/cap-react/src/antd/admin/formComponents/widgets/index.js
@@ -1,0 +1,7 @@
+import SliderWidget from "./SliderWidget";
+
+const widgets = {
+  slider: SliderWidget,
+};
+
+export default widgets;

--- a/ui/cap-react/src/antd/admin/utils/fieldTypes.js
+++ b/ui/cap-react/src/antd/admin/utils/fieldTypes.js
@@ -293,6 +293,12 @@ const simple = {
     optionsSchemaUiSchema: {
       readOnly: extra.optionsSchemaUiSchema.readOnly,
     },
+    optionsUiSchema: {
+      ...common.optionsUiSchema,
+    },
+    optionsUiSchemaUiSchema: {
+      ...common.optionsUiSchemaUiSchema,
+    },
     default: {
       schema: {
         type: "string",

--- a/ui/cap-react/src/antd/admin/utils/fieldTypes.js
+++ b/ui/cap-react/src/antd/admin/utils/fieldTypes.js
@@ -46,16 +46,23 @@ const common = {
         title: "UI Options",
         properties: {
           span: {
-            type: "string",
             title: "Field Width",
-            enum: [6, 8, 12, 16, 18, 24],
-            enumNames: ["25%", "33%", "50%", "66%", "75%", "100%"],
+            type: "integer",
+            defaultValue: 24,
+            values: [6, 8, 12, 16, 18, 24],
+            labels: ["25%", "33%", "50%", "66%", "75%", "100%"],
           },
         },
       },
     },
   },
-  optionsUiSchemaUiSchema: {},
+  optionsUiSchemaUiSchema: {
+    "ui:options": {
+      span: {
+        "ui:widget": "slider",
+      },
+    },
+  },
 };
 
 const extra = {
@@ -69,7 +76,7 @@ const extra = {
   },
   optionsSchemaUiSchema: {
     readOnly: {
-      "ui:widget": "select",
+      "ui:widget": "switch",
     },
   },
 };
@@ -118,7 +125,7 @@ const simple = {
     },
     optionsUiSchema: {
       type: "object",
-      title: "Switch Widget UI Options",
+      title: "UI Schema",
       properties: {
         "ui:options": {
           type: "object",
@@ -210,7 +217,7 @@ const simple = {
     },
     optionsUiSchema: {
       type: "object",
-      title: "Switch Widget UI Options",
+      title: "UI Schema",
       properties: {
         "ui:options": {
           type: "object",
@@ -966,7 +973,7 @@ const advanced = {
     optionsSchemaUiSchema: {},
     optionsUiSchema: {
       type: "object",
-      title: "Id Fetcher UI Options",
+      title: "UI Schema",
       properties: {
         ...common.optionsUiSchema.properties,
         "ui:servicesList": {

--- a/ui/cap-react/src/antd/admin/utils/index.js
+++ b/ui/cap-react/src/antd/admin/utils/index.js
@@ -56,3 +56,11 @@ export const isItTheArrayField = (schema, uiSchema) => {
     schema.type === "array" && !uiSchema["ui:field"] && !uiSchema["ui:widget"]
   );
 };
+
+export const SIZE_OPTIONS = {
+  xsmall: 8,
+  small: 12,
+  medium: 16,
+  large: 20,
+  xlarge: 24,
+};

--- a/ui/cap-react/src/antd/admin/utils/schemaSettings.js
+++ b/ui/cap-react/src/antd/admin/utils/schemaSettings.js
@@ -5,21 +5,21 @@ export const commonSchema = {
     name: {
       title: "Field/property name",
       description: "Should be a string without spaces or other special chars",
-      type: "string"
+      type: "string",
     },
     path: {
       title: "Path",
       description:
         "The title of the form field. How it will be displayed on the rendered form.",
-      type: "string"
-    }
-  }
+      type: "string",
+    },
+  },
 };
 
 export const propKeySchema = {
   title: "Property Key",
   description: "Should be a string without spaces or other special chars",
-  type: "string"
+  type: "string",
 };
 
 export const schemaSchema = {
@@ -29,33 +29,33 @@ export const schemaSchema = {
     type: {
       title: "Property Type",
       type: "string",
-      enum: ["string", "object", "array", "number", "boolean"]
+      enum: ["string", "object", "array", "number", "boolean"],
     },
     title: {
       title: "Title",
-      type: "string"
+      type: "string",
     },
     description: {
       title: "Description",
-      type: "string"
+      type: "string",
     },
     placeholder: {
       title: "Placeholder",
-      type: "string"
+      type: "string",
     },
     format: {
       title: "Format/Widget",
-      type: "string"
-    }
-  }
+      type: "string",
+    },
+  },
 };
 
 export const uiSchema = {
   type: {
     "ui:options": {
-      hidden: true
-    }
-  }
+      hidden: true,
+    },
+  },
 };
 
 export const configSchema = {
@@ -66,41 +66,34 @@ export const configSchema = {
       name: {
         type: "string",
         title: "Schema ID",
-        description: "Unique ID of the schema"
+        description: "Unique ID of the schema",
       },
       version: {
         type: "string",
         title: "Version",
-        pattern: "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$"
+        pattern: "^([0-9]+)\\.([0-9]+)\\.([0-9]+)$",
       },
       fullname: {
         type: "string",
         title: "Fullname",
-        description: "It will be used to display the schema on the UI"
+        description: "It will be used to display the schema on the UI",
       },
       experiment: {
         type: "string",
         title: "Experiment",
-        enum: ["CMS", "LHCb", "ATLAS", "ALICE"]
+        enum: ["CMS", "LHCb", "ATLAS", "ALICE"],
       },
       is_indexed: {
         type: "boolean",
-        title: "Should be visible and indexed?"
+        title: "Should be visible and indexed?",
       },
       use_deposit_as_record: {
         type: "boolean",
-        title: "Use same schema for deposit and record?"
-      }
-    }
+        title: "Use same schema for deposit and record?",
+      },
+    },
   },
   uiSchema: {
-    use_deposit_as_record: {
-      "ui:options": {
-        grid: {
-          gridColumns: "3/5"
-        }
-      }
-    },
     "ui:order": [
       "name",
       "version",
@@ -108,35 +101,12 @@ export const configSchema = {
       "experiment",
       "is_indexed",
       "use_deposit_as_record",
-      "*"
+      "*",
     ],
-    name: {
-      "ui:options": {
-        grid: {
-          gridColumns: "1/3"
-        }
-      }
-    },
     version: {
       "ui:options": {
-        grid: {
-          gridColumns: "3/5"
-        },
-        disableRegex: true
-      }
+        disableRegex: true,
+      },
     },
-    "ui:options": {
-      size: "large",
-      align: "center"
-    },
-    fullname: {},
-    is_indexed: {
-      "ui:options": {
-        grid: {
-          gridColumns: "1/3"
-        }
-      }
-    },
-    experiment: {}
-  }
+  },
 };

--- a/ui/cap-react/src/antd/collection/CollectionPermissionItem.js
+++ b/ui/cap-react/src/antd/collection/CollectionPermissionItem.js
@@ -11,6 +11,7 @@ const CollectionPermissionItem = ({ permissions, title }) => {
           permissions.map((item, index) => <Tag key={item + index}>{item}</Tag>)
         ) : (
           <Empty
+            image={Empty.PRESENTED_IMAGE_SIMPLE}
             description="  There are not egroups/users email addresses provided for this
           category"
           />
@@ -22,7 +23,7 @@ const CollectionPermissionItem = ({ permissions, title }) => {
 
 CollectionPermissionItem.propTypes = {
   permissions: PropTypes.array,
-  title: PropTypes.string
+  title: PropTypes.string,
 };
 
 export default CollectionPermissionItem;

--- a/ui/cap-react/src/antd/drafts/components/Connect/Connect.js
+++ b/ui/cap-react/src/antd/drafts/components/Connect/Connect.js
@@ -32,7 +32,7 @@ const Connect = ({
   const [myRepo, setMyRepo] = useState(null);
   const [error, setError] = useState(null);
 
-  const getEvenTypeLabel = (type) => {
+  const getEvenTypeLabel = type => {
     switch (type) {
       case "release":
         return "on Tag/Release";
@@ -46,7 +46,7 @@ const Connect = ({
   const columns = [
     {
       title: "Ref",
-      render: (snap) => {
+      render: snap => {
         return snap.payload.event_type == "release" ? (
           <Tag>{snap.payload.release.tag}</Tag>
         ) : (
@@ -61,7 +61,7 @@ const Connect = ({
     },
     {
       title: "Created",
-      render: (snap) => {
+      render: snap => {
         return (
           snap.created && <ReactTimeago date={snap.created} minPeriod="60" />
         );
@@ -71,7 +71,7 @@ const Connect = ({
     },
     {
       title: "Link",
-      render: (snap) => (
+      render: snap => (
         <Typography.Link href={snap.payload.link} target="_blank">
           link
         </Typography.Link>
@@ -112,7 +112,7 @@ const Connect = ({
         setMyRepo(null);
         form.resetFields();
       })
-      .catch((e) =>
+      .catch(e =>
         setError({
           ...e.error.response.data,
           type: event_type ? event_type : "upload",
@@ -127,8 +127,7 @@ const Connect = ({
       setError(null);
       return;
     }
-    let regex =
-      /(https|http):\/\/(github\.com|gitlab\.cern\.ch|gitlab-test\.cern\.ch)[:|\/]([\w\.-]+)\/([\w\.-]+)(\.git|\/tree\/|\/-\/tree\/|\/blob\/|\/-\/blob\/|\/releases\/tag\/|\/-\/tags\/)?\/?([\w.-]+)?\/?(.+)?/; //eslint-disable-line
+    let regex = /(https|http):\/\/(github\.com|gitlab\.cern\.ch|gitlab-test\.cern\.ch)[:|\/]([\w\.-]+)\/([\w\.-]+)(\.git|\/tree\/|\/-\/tree\/|\/blob\/|\/-\/blob\/|\/releases\/tag\/|\/-\/tags\/)?\/?([\w.-]+)?\/?(.+)?/; //eslint-disable-line
     let repo = value.match(regex);
     let [href, scheme, resource, owner, name, type, ref, filepath] = repo;
     const acceptedResources = [
@@ -211,7 +210,7 @@ const Connect = ({
         <Card title="Connected Repositories">
           {repos && repos.length > 0 ? (
             <Collapse>
-              {repos.map((repo) => (
+              {repos.map(repo => (
                 <Collapse.Panel
                   header={`${repo.owner}/${repo.name}`}
                   key={repo.id}
@@ -230,7 +229,10 @@ const Connect = ({
               ))}
             </Collapse>
           ) : (
-            <Empty description="No connected repositories" />
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description="No connected repositories"
+            />
           )}
         </Card>
       </Space>

--- a/ui/cap-react/src/antd/drafts/components/Overview/Overview.js
+++ b/ui/cap-react/src/antd/drafts/components/Overview/Overview.js
@@ -9,7 +9,7 @@ import {
   Row,
   Space,
   Tag,
-  Typography
+  Typography,
 } from "antd";
 import { transformSchema } from "../../utils/transformSchema";
 import JSONSchemaPreviewer from "../../../partials/JSONSchemaPreviewer";
@@ -17,7 +17,7 @@ import {
   CodeOutlined,
   FolderOutlined,
   InfoCircleOutlined,
-  UserOutlined
+  UserOutlined,
 } from "@ant-design/icons";
 import OverviewLoading from "./OverviewLoading";
 import DepositFilesList from "../../../partials/FileList";
@@ -39,16 +39,16 @@ const Overview = ({
   mySchema,
   access,
   loading,
-  history
+  history,
 }) => {
   const { users, roles } = useMemo(() => calculateCollaborators(access), [
-    access
+    access,
   ]);
 
   const infoArray = [
     {
       text: <Typography.Text>{revision} revision</Typography.Text>,
-      icon: <InfoCircleOutlined />
+      icon: <InfoCircleOutlined />,
     },
     {
       text: (
@@ -57,7 +57,7 @@ const Overview = ({
           {users || 0} users / {roles || 0} roles
         </Typography.Text>
       ),
-      icon: <UserOutlined />
+      icon: <UserOutlined />,
     },
     {
       text: (
@@ -65,11 +65,11 @@ const Overview = ({
           {webhooks && webhooks.length} repositories
         </Typography.Text>
       ),
-      icon: <CodeOutlined />
+      icon: <CodeOutlined />,
     },
     {
       text: <Typography.Text>{files && files.size} files</Typography.Text>,
-      icon: <FolderOutlined />
+      icon: <FolderOutlined />,
     },
     {
       text: (
@@ -78,8 +78,8 @@ const Overview = ({
           {(schema && schema.version) || "-"} schema version
         </Typography.Text>
       ),
-      icon: <InfoCircleOutlined />
-    }
+      icon: <InfoCircleOutlined />,
+    },
   ];
   if (loading)
     return (
@@ -88,7 +88,7 @@ const Overview = ({
       </Col>
     );
   return (
-    <Col xxl={16} lg={18} xs={22} sm={22} style={{ padding: "0 0 15px 0 " }}>
+    <Col xxl={16} lg={18} xs={22} sm={22} style={{ paddingBottom: "15px" }}>
       <Space direction="vertical" size="middle" style={{ width: "100%" }}>
         <Row
           justify="space-around"
@@ -152,7 +152,7 @@ const Overview = ({
                 onClick={() => {
                   history.push({
                     pathname: `/drafts/${draft_id}/edit`,
-                    state: { mode: "preview" }
+                    state: { mode: "preview" },
                   });
                 }}
               >
@@ -223,7 +223,7 @@ Overview.propTypes = {
   mySchema: PropTypes.object,
   access: PropTypes.object,
   loading: PropTypes.bool,
-  history: PropTypes.object
+  history: PropTypes.object,
 };
 
 export default Overview;

--- a/ui/cap-react/src/antd/drafts/components/Overview/Overview.js
+++ b/ui/cap-react/src/antd/drafts/components/Overview/Overview.js
@@ -182,7 +182,10 @@ const Overview = ({
           {webhooks && webhooks.length > 0 ? (
             <InfoArrayBox items={webhooks} type="repositories" />
           ) : (
-            <Empty description="No connected repositories yet" />
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description="No connected repositories yet"
+            />
           )}
         </Card>
         <Card title="Uploaded Repositories">
@@ -191,7 +194,10 @@ const Overview = ({
           files.filter(item => item.key.startsWith("repositories")).size > 0 ? (
             <DepositFilesList files={files} renderList={["repositories"]} />
           ) : (
-            <Empty description="No uploaded repositories yet" />
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description="No uploaded repositories yet"
+            />
           )}
         </Card>
         <Card title="Uploaded Files">
@@ -201,7 +207,10 @@ const Overview = ({
             0 ? (
             <DepositFilesList files={files} renderList={["files"]} />
           ) : (
-            <Empty description="No uploaded files yet" />
+            <Empty
+              image={Empty.PRESENTED_IMAGE_SIMPLE}
+              description="No uploaded files yet"
+            />
           )}
         </Card>
       </Space>

--- a/ui/cap-react/src/antd/drafts/components/SideBar/DraftSideBar.js
+++ b/ui/cap-react/src/antd/drafts/components/SideBar/DraftSideBar.js
@@ -20,7 +20,10 @@ const DraftSideBar = ({ visibleFileDrawer, onClose }) => {
       <SideBar />
     </Drawer>
   ) : (
-    <Col xxl={6} style={{ height: "100%", overflowY: "scroll" }}>
+    <Col
+      xxl={6}
+      style={{ height: "100%", overflowY: "scroll", backgroundColor: "#fff" }}
+    >
       <SideBar />
     </Col>
   );

--- a/ui/cap-react/src/antd/drafts/components/SideBar/DraftSideBar.js
+++ b/ui/cap-react/src/antd/drafts/components/SideBar/DraftSideBar.js
@@ -20,7 +20,7 @@ const DraftSideBar = ({ visibleFileDrawer, onClose }) => {
       <SideBar />
     </Drawer>
   ) : (
-    <Col xxl={6}>
+    <Col xxl={6} style={{ height: "100%", overflowY: "scroll" }}>
       <SideBar />
     </Col>
   );
@@ -28,7 +28,7 @@ const DraftSideBar = ({ visibleFileDrawer, onClose }) => {
 
 DraftSideBar.propTypes = {
   visibleFileDrawer: PropTypes.bool,
-  onClose: PropTypes.func
+  onClose: PropTypes.func,
 };
 
 export default DraftSideBar;

--- a/ui/cap-react/src/antd/drafts/components/SideBar/SideBar.js
+++ b/ui/cap-react/src/antd/drafts/components/SideBar/SideBar.js
@@ -21,7 +21,7 @@ const SideBar = ({
   canUpdate,
   files,
   links,
-  getBucketById
+  getBucketById,
 }) => {
   const contents = [
     {
@@ -30,7 +30,7 @@ const SideBar = ({
         <Typography.Text ellipsis copyable>
           {id}
         </Typography.Text>
-      )
+      ),
     },
     {
       title: <Typography.Text>Collection</Typography.Text>,
@@ -40,7 +40,7 @@ const SideBar = ({
             {schema.fullname} v{schema.version}
           </Tag>
         </Link>
-      )
+      ),
     },
     {
       title: <Typography.Text>Status</Typography.Text>,
@@ -51,11 +51,11 @@ const SideBar = ({
         >
           {status}
         </Tag>
-      )
+      ),
     },
     {
       title: <Typography.Text>Creator</Typography.Text>,
-      content: created_by && created_by.email
+      content: created_by && created_by.email,
     },
     {
       title: <Typography.Text>Published URL</Typography.Text>,
@@ -65,21 +65,21 @@ const SideBar = ({
         </Link>
       ) : (
         <Typography.Text>Not published yet</Typography.Text>
-      )
+      ),
     },
     {
       title: <Typography.Text>Created</Typography.Text>,
-      content: created && <Timeago date={created} minPeriod="60" />
+      content: created && <Timeago date={created} minPeriod="60" />,
     },
     {
       title: <Typography.Text>Last Updated</Typography.Text>,
-      content: updated && <Timeago date={updated} minPeriod="60" />
-    }
+      content: updated && <Timeago date={updated} minPeriod="60" />,
+    },
   ];
 
   const [showModal, setShowModal] = useState(false);
   return (
-    <Row style={{ backgroundColor: "#fff", height: "100%" }}>
+    <Row style={{ backgroundColor: "#fff" }}>
       <Space direction="vertical" style={{ width: "100%", padding: "10px" }}>
         <Descriptions bordered size="small">
           {contents.map((content, idx) => (
@@ -118,7 +118,7 @@ const SideBar = ({
                     </Space>
                   )}
                 />
-              )
+              ),
           ]}
         >
           <DepositFilesList files={files} />
@@ -141,7 +141,7 @@ SideBar.propTypes = {
   files: PropTypes.object,
   links: PropTypes.object,
   getBucketById: PropTypes.func,
-  toggleFilemanagerLayer: PropTypes.func
+  toggleFilemanagerLayer: PropTypes.func,
 };
 
 export default SideBar;

--- a/ui/cap-react/src/antd/drafts/components/SideBar/SideBar.js
+++ b/ui/cap-react/src/antd/drafts/components/SideBar/SideBar.js
@@ -27,7 +27,11 @@ const SideBar = ({
     {
       title: <Typography.Text>ID</Typography.Text>,
       content: (
-        <Typography.Text ellipsis copyable>
+        <Typography.Text
+          style={{ maxWidth: "99%" }}
+          ellipsis={{ tooltip: id }}
+          copyable
+        >
           {id}
         </Typography.Text>
       ),
@@ -79,7 +83,7 @@ const SideBar = ({
 
   const [showModal, setShowModal] = useState(false);
   return (
-    <Row style={{ backgroundColor: "#fff" }}>
+    <Row style={{ backgroundColor: "#fff", height: "100%" }}>
       <Space direction="vertical" style={{ width: "100%", padding: "10px" }}>
         <Descriptions bordered size="small">
           {contents.map((content, idx) => (

--- a/ui/cap-react/src/antd/drafts/components/SideBar/SideBar.js
+++ b/ui/cap-react/src/antd/drafts/components/SideBar/SideBar.js
@@ -83,7 +83,7 @@ const SideBar = ({
 
   const [showModal, setShowModal] = useState(false);
   return (
-    <Row style={{ backgroundColor: "#fff", height: "100%" }}>
+    <Row style={{ height: "100%" }}>
       <Space direction="vertical" style={{ width: "100%", padding: "10px" }}>
         <Descriptions bordered size="small">
           {contents.map((content, idx) => (

--- a/ui/cap-react/src/antd/forms/fields/CapFiles.js
+++ b/ui/cap-react/src/antd/forms/fields/CapFiles.js
@@ -38,7 +38,7 @@ const CapFiles = ({ uiSchema, files, onChange, formData }) => {
           justify="space-between"
           style={{
             borderBottom: "1px solid rgba(0, 0, 0, 0.06)",
-            padding: "5px"
+            padding: "5px",
           }}
         >
           <Space>
@@ -61,7 +61,10 @@ const CapFiles = ({ uiSchema, files, onChange, formData }) => {
           />
         </Row>
       ) : (
-        <Button onClick={() => setShowModal(true)}>
+        <Button
+          onClick={() => setShowModal(true)}
+          style={{ whiteSpace: "normal", height: "auto" }}
+        >
           {(uiSchema && uiSchema.capFilesDescription) ||
             "Select a file or a repository from your list to link here"}
         </Button>
@@ -74,16 +77,16 @@ CapFiles.propTypes = {
   uiSchema: PropTypes.object,
   files: PropTypes.object,
   onChange: PropTypes.object,
-  formData: PropTypes.object
+  formData: PropTypes.object,
 };
 
 const mapStateToProps = state => ({
   files: state.draftItem.get("bucket"),
-  pathSelected: state.draftItem.get("pathSelected")
+  pathSelected: state.draftItem.get("pathSelected"),
 });
 
 const mapDispatchToProps = dispatch => ({
-  selectPath: (path, type) => dispatch(selectPath(path, type))
+  selectPath: (path, type) => dispatch(selectPath(path, type)),
 });
 
 export default connect(

--- a/ui/cap-react/src/antd/forms/templates/ArrayFieldTemplates/EmptyArrayField.js
+++ b/ui/cap-react/src/antd/forms/templates/ArrayFieldTemplates/EmptyArrayField.js
@@ -12,22 +12,25 @@ const EmptyArrayField = ({
 }) => {
   return (
     <Empty
+      image={Empty.PRESENTED_IMAGE_SIMPLE}
       imageStyle={{
-        height: 60,
+        height: 35,
       }}
+      style={{ margin: "5px" }}
       description={"No Items added"}
     >
-      {canAdd && !readonly && (
-        <Button
-          className="array-item-add"
-          disabled={disabled}
-          onClick={onAddClick}
-          type="primary"
-          icon={<PlusCircleOutlined />}
-        >
-          Add {options && options.addLabel ? options.addLabel : `Item`}
-        </Button>
-      )}
+      {canAdd &&
+        !readonly && (
+          <Button
+            className="array-item-add"
+            disabled={disabled}
+            onClick={onAddClick}
+            type="primary"
+            icon={<PlusCircleOutlined />}
+          >
+            Add {options && options.addLabel ? options.addLabel : `Item`}
+          </Button>
+        )}
     </Empty>
   );
 };

--- a/ui/cap-react/src/antd/forms/templates/Field/FieldTemplate.js
+++ b/ui/cap-react/src/antd/forms/templates/Field/FieldTemplate.js
@@ -96,9 +96,7 @@ const FieldTemplate = ({
   else {
     return (
       <Row justify={uiOptions.justify || "center"}>
-        <Col xs={22} sm={18}>
-          {content}
-        </Col>
+        <Col xs={24}>{content}</Col>
       </Row>
     );
   }

--- a/ui/cap-react/src/antd/forms/templates/Field/FieldTemplate.js
+++ b/ui/cap-react/src/antd/forms/templates/Field/FieldTemplate.js
@@ -6,6 +6,7 @@ import FieldHeader from "./FieldHeader";
 
 import WrapIfAdditional from "./WrapIfAdditional";
 import { Col, Row } from "antd";
+import { SIZE_OPTIONS } from "../../../admin/utils";
 
 const VERTICAL_LABEL_COL = { span: 24 };
 const VERTICAL_WRAPPER_COL = { span: 24 };
@@ -96,7 +97,7 @@ const FieldTemplate = ({
   else {
     return (
       <Row justify={uiOptions.justify || "center"}>
-        <Col xs={24}>{content}</Col>
+        <Col xs={SIZE_OPTIONS[uiOptions.size] || 24}>{content}</Col>
       </Row>
     );
   }

--- a/ui/cap-react/src/antd/forms/templates/ObjectFieldTemplate.js
+++ b/ui/cap-react/src/antd/forms/templates/ObjectFieldTemplate.js
@@ -81,16 +81,12 @@ const ObjectFieldTemplate = ({
   if (uiSchema["ui:object"] == "tabView")
     return <TabField uiSchema={uiSchema} properties={properties} />;
   return (
-    <fieldset
-      style={{ marginLeft: "12px", marginRight: "12px" }}
-      id={idSchema.$id}
-    >
+    <fieldset style={{ margin: "0 12px" }} id={idSchema.$id}>
       <Row gutter={rowGutter}>
         {uiSchema["ui:title"] !== false &&
           (uiSchema["ui:title"] || title) && (
             <Col
               style={{
-                borderBottsom: "1px solid",
                 padding: "0",
                 marginBottom: "12px",
               }}

--- a/ui/cap-react/src/antd/forms/templates/ObjectFieldTemplate.js
+++ b/ui/cap-react/src/antd/forms/templates/ObjectFieldTemplate.js
@@ -118,7 +118,7 @@ const ObjectFieldTemplate = ({
             </Col>
           )}
         <Col span={24} className="nestedObject">
-          <Row>
+          <Row gutter={10}>
             {properties.filter(e => !e.hidden).map(element => (
               <Col key={element.name} span={calculateColSpan(element)}>
                 {element.content}

--- a/ui/cap-react/src/antd/partials/EditableField/EditableField.js
+++ b/ui/cap-react/src/antd/partials/EditableField/EditableField.js
@@ -7,7 +7,8 @@ const EditableField = ({
   text,
   isEditable = false,
   emptyValue = "Untitled Document",
-  onUpdate = () => {}
+  hideButtons,
+  onUpdate = () => {},
 }) => {
   const [editMode, setEditMode] = useState(false);
   const [currentValue, setCurrentValue] = useState(text);
@@ -48,12 +49,16 @@ const EditableField = ({
         data-cy="editableInput"
         autoFocus={true}
       />
-      <CheckOutlined onClick={handleApprove} style={{ color: "#389e0d" }} />
-      <CloseOutlined
-        style={{ color: "#cf1322" }}
-        onClick={handleReject}
-        data-cy="editableTitleClose"
-      />
+      {!hideButtons && (
+        <React.Fragment>
+          <CheckOutlined onClick={handleApprove} style={{ color: "#389e0d" }} />
+          <CloseOutlined
+            style={{ color: "#cf1322" }}
+            onClick={handleReject}
+            data-cy="editableTitleClose"
+          />
+        </React.Fragment>
+      )}
     </Space>
   );
 };
@@ -62,7 +67,8 @@ EditableField.propTypes = {
   text: PropTypes.string,
   emptyValue: PropTypes.string,
   onUpdate: PropTypes.func,
-  isEditable: PropTypes.bool
+  hideButtons: PropTypes.bool,
+  isEditable: PropTypes.bool,
 };
 
 export default EditableField;

--- a/ui/cap-react/src/antd/partials/EditableField/EditableField.js
+++ b/ui/cap-react/src/antd/partials/EditableField/EditableField.js
@@ -7,7 +7,6 @@ const EditableField = ({
   text,
   isEditable = false,
   emptyValue = "Untitled Document",
-  hideButtons,
   onUpdate = () => {},
 }) => {
   const [editMode, setEditMode] = useState(false);
@@ -49,16 +48,12 @@ const EditableField = ({
         data-cy="editableInput"
         autoFocus={true}
       />
-      {!hideButtons && (
-        <React.Fragment>
-          <CheckOutlined onClick={handleApprove} style={{ color: "#389e0d" }} />
-          <CloseOutlined
-            style={{ color: "#cf1322" }}
-            onClick={handleReject}
-            data-cy="editableTitleClose"
-          />
-        </React.Fragment>
-      )}
+      <CheckOutlined onClick={handleApprove} style={{ color: "#389e0d" }} />
+      <CloseOutlined
+        style={{ color: "#cf1322" }}
+        onClick={handleReject}
+        data-cy="editableTitleClose"
+      />
     </Space>
   );
 };
@@ -67,7 +62,6 @@ EditableField.propTypes = {
   text: PropTypes.string,
   emptyValue: PropTypes.string,
   onUpdate: PropTypes.func,
-  hideButtons: PropTypes.bool,
   isEditable: PropTypes.bool,
 };
 

--- a/ui/cap-react/src/antd/partials/FileList/components/Files.js
+++ b/ui/cap-react/src/antd/partials/FileList/components/Files.js
@@ -36,6 +36,7 @@ const Files = ({
                 treeData={repos[0].children || []}
                 selectable={false}
                 showIcon={false}
+                style={{ overflowY: "auto" }}
               />
             ) : (
               <Empty
@@ -59,6 +60,7 @@ const Files = ({
                 treeData={files.children}
                 selectable={false}
                 showIcon={false}
+                style={{ overflowY: "auto" }}
               />
             ) : (
               <Empty

--- a/ui/cap-react/src/antd/partials/FileList/components/Files.js
+++ b/ui/cap-react/src/antd/partials/FileList/components/Files.js
@@ -25,10 +25,7 @@ const Files = ({
     const choices = {
       repositories: (
         <React.Fragment>
-          <Space
-            direction="vertical"
-            style={{ width: "100%", paddingBottom: "20px" }}
-          >
+          <Space direction="vertical" style={{ width: "100%" }}>
             {displayTitle && (
               <Divider style={{ fontSize: "1em", margin: "0" }}>
                 All Repositories
@@ -41,17 +38,17 @@ const Files = ({
                 showIcon={false}
               />
             ) : (
-              <Empty description="No repos uploaded yet" />
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description="No repos uploaded yet"
+              />
             )}
           </Space>
         </React.Fragment>
       ),
       files: (
         <React.Fragment>
-          <Space
-            direction="vertical"
-            style={{ width: "100%", paddingBottom: "20px" }}
-          >
+          <Space direction="vertical" style={{ width: "100%" }}>
             {displayTitle && (
               <Divider style={{ fontSize: "1em", margin: "0" }}>
                 All Files
@@ -64,7 +61,10 @@ const Files = ({
                 showIcon={false}
               />
             ) : (
-              <Empty description="No files uploaded yet" />
+              <Empty
+                image={Empty.PRESENTED_IMAGE_SIMPLE}
+                description="No files uploaded yet"
+              />
             )}
           </Space>
         </React.Fragment>

--- a/ui/cap-react/src/antd/partials/FileList/components/Files.js
+++ b/ui/cap-react/src/antd/partials/FileList/components/Files.js
@@ -8,7 +8,7 @@ const Files = ({
   renderList = ["files", "repositories", "title"],
   moodaUpate,
   memoFiles = Map({}),
-  onFileClick = null
+  onFileClick = null,
 }) => {
   let data = constructTree(
     memoFiles,
@@ -17,7 +17,7 @@ const Files = ({
   );
   let repos = filter(data.children, { name: "repositories" });
   let files = {
-    children: filter(data.children, item => item.name != "repositories")
+    children: filter(data.children, item => item.name != "repositories"),
   };
   let displayTitle = renderList.includes("title");
 
@@ -25,25 +25,33 @@ const Files = ({
     const choices = {
       repositories: (
         <React.Fragment>
-          {displayTitle && (
-            <Divider style={{ fontSize: "1em", margin: "0" }}>
-              All Repositories
-            </Divider>
-          )}
-          {repos && repos.length > 0 ? (
-            <Tree.DirectoryTree
-              treeData={repos[0].children || []}
-              selectable={false}
-              showIcon={false}
-            />
-          ) : (
-            <Empty description="No repos uploaded yet" />
-          )}
+          <Space
+            direction="vertical"
+            style={{ width: "100%", paddingBottom: "20px" }}
+          >
+            {displayTitle && (
+              <Divider style={{ fontSize: "1em", margin: "0" }}>
+                All Repositories
+              </Divider>
+            )}
+            {repos && repos.length > 0 ? (
+              <Tree.DirectoryTree
+                treeData={repos[0].children || []}
+                selectable={false}
+                showIcon={false}
+              />
+            ) : (
+              <Empty description="No repos uploaded yet" />
+            )}
+          </Space>
         </React.Fragment>
       ),
       files: (
         <React.Fragment>
-          <Space direction="vertical" style={{ width: "100%" }}>
+          <Space
+            direction="vertical"
+            style={{ width: "100%", paddingBottom: "20px" }}
+          >
             {displayTitle && (
               <Divider style={{ fontSize: "1em", margin: "0" }}>
                 All Files
@@ -60,7 +68,7 @@ const Files = ({
             )}
           </Space>
         </React.Fragment>
-      )
+      ),
     };
 
     return choices[value];
@@ -72,7 +80,7 @@ const Files = ({
 Files.propTypes = {
   renderList: PropTypes.array,
   modalUpdate: PropTypes.func,
-  memoFiles: PropTypes.object
+  memoFiles: PropTypes.object,
 };
 
 export default React.memo(Files);

--- a/ui/cap-react/src/antd/settings/components/Applications.js
+++ b/ui/cap-react/src/antd/settings/components/Applications.js
@@ -29,7 +29,7 @@ const Applications = ({
           layout="vertical"
           form={form}
           initialValues={{ tokenAccessName: "" }}
-          onFinish={(values) => {
+          onFinish={values => {
             createToken({
               name: values.tokenAccessName,
               scopes: ["deposit:write"],
@@ -98,7 +98,7 @@ const Applications = ({
                 title: "Action",
                 width: "20%",
                 key: "action",
-                render: (token) => (
+                render: token => (
                   <Button
                     data-cy={token.name}
                     type="link"
@@ -111,7 +111,10 @@ const Applications = ({
             ]}
           />
         ) : (
-          <Empty description="Add a new token to grant access to CAP client and API">
+          <Empty
+            image={Empty.PRESENTED_IMAGE_SIMPLE}
+            description="Add a new token to grant access to CAP client and API"
+          >
             <Button
               type="primary"
               data-cy="settingsAddToken"

--- a/ui/cap-react/src/components/search/SearchPage.js
+++ b/ui/cap-react/src/components/search/SearchPage.js
@@ -29,7 +29,7 @@ class SearchPage extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      layerActive: false
+      layerActive: false,
     };
   }
 
@@ -49,7 +49,7 @@ class SearchPage extends React.Component {
     const location = {
       search: `${queryString.stringify(
         Object.assign(currentParams, { size: size })
-      )}`
+      )}`,
     };
 
     this.props.history.push(location);
@@ -68,7 +68,7 @@ class SearchPage extends React.Component {
     }
 
     const location = {
-      search: queryString.stringify(currentParams)
+      search: queryString.stringify(currentParams),
     };
 
     this.props.history.push(location);
@@ -80,7 +80,7 @@ class SearchPage extends React.Component {
     const location = {
       search: `${queryString.stringify(
         Object.assign(currentParams, { sort: sort })
-      )}`
+      )}`,
     };
     this.props.history.push(location);
   };
@@ -97,7 +97,7 @@ class SearchPage extends React.Component {
       }
     }
     const location = {
-      search: queryString.stringify(currentParams)
+      search: queryString.stringify(currentParams),
     };
     this.props.history.push(location);
   };
@@ -108,7 +108,7 @@ class SearchPage extends React.Component {
     const location = {
       search: `${queryString.stringify(
         Object.assign(currentParams, { page: page, size: size })
-      )}`
+      )}`,
     };
     this.props.history.push(location);
   }
@@ -146,7 +146,7 @@ class SearchPage extends React.Component {
         </Box>
       ) : this.props.error ? (
         <Box flex={false} justify="center" align="center">
-          <Empty />
+          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
           <Label style={{ textAlign: "center" }}>
             There was an error with your request <br />
             please try again
@@ -154,7 +154,7 @@ class SearchPage extends React.Component {
         </Box>
       ) : total === 0 ? (
         <Box flex={false} justify="center" align="center">
-          <Empty />
+          <Empty image={Empty.PRESENTED_IMAGE_SIMPLE} />
           <Label style={{ textAlign: "center" }}>
             No search results were found <br />or <br />you have no permission
             to see them
@@ -309,7 +309,7 @@ SearchPage.propTypes = {
   location: PropTypes.object.isRequired,
   selectedAggs: PropTypes.object.isRequired,
   results: PropTypes.object.isRequired,
-  error: PropTypes.bool
+  error: PropTypes.bool,
 };
 
 function mapStateToProps(state) {
@@ -317,13 +317,13 @@ function mapStateToProps(state) {
     results: state.search.getIn(["results"]),
     loading: state.search.getIn(["loading"]),
     selectedAggs: state.search.getIn(["selectedAggs"]),
-    error: state.search.getIn(["error"])
+    error: state.search.getIn(["error"]),
   };
 }
 
 function mapDispatchToProps(dispatch) {
   return {
-    fetchSearch: match => dispatch(fetchSearch(match))
+    fetchSearch: match => dispatch(fetchSearch(match)),
   };
 }
 


### PR DESCRIPTION
Closes #2681

* Removed unnecessary margins in the PropKeyEditor (aka left column).
* Added tabs to the PropKeyEditor instead of having two collapsible sections one for schema settings and one for ui schema settings.
* Added a PopConfirm to the field delete button, instead of the old dialog.
* Replaced the tags indicating the "path" of the field in the tree with breadcrumbs. The title is now shown in a new line instead of as an editable tag (it's still inline editable).
* Replaced the select for the readonly setting with a switch.
* Replaced the select for the field width ui setting with a slider.
* Moved the gear icon on top of the field tree to the right and made it an actual button. This is for editing the schema settings for the root field. The UI settings that were hardcoded at the bottom of the schema settings tab for the root field are now in the ui schema settings tab (instead of showing the usual ui schema settings, which are not useful for the root field).

Closes #2696 

* Fixed the width of the button for the CAPFiles field (now it breaks to the next line instead of overflowing horizontally)

Closes #2720 

* Fixed a weird bug when switching between fields while the UI Settings tab is open.
* Also fixed an issue in which the field width slider wasn't showing the correct selected value when switching back and forth between fields

Things that could still be improved:
* In the ui schema settings tab, due to how the rjsf object is structured (with the `ui:options` and such), the settings are shown inside a card component which looks off. A "UI Schema" and a "UI Options" title below are displayed as well, which also looks weird and takes up some space. These things are hard to change since they come from the rjsf schemas.
* It would be cool to put the description of the fields in the PropKeyEditor as a tooltip (in a question mark icon). However, rjsf/antd does not support this right now. There's an [open PR](https://github.com/rjsf-team/react-jsonschema-form/pull/2740) for that so let's see if it ends up being implemented. Otherwise in the future we could implement something ourselves.

Signed-off-by: Miguel Garcia Garcia <miguel.garcia.garcia@cern.ch>