### PR TITLE
ui: change the looks of the admin toolbar

### DIFF
--- a/ui/cap-react/src/antd/admin/components/AdminPanel.js
+++ b/ui/cap-react/src/antd/admin/components/AdminPanel.js
@@ -1,12 +1,12 @@
 import React, { useEffect } from "react";
 import PropTypes from "prop-types";
-import { Layout } from "antd";
 import Header from "../containers/Header";
 import { CMS, CMS_EDIT, CMS_NEW, CMS_NOTIFICATION } from "../../routes";
 import DocumentTitle from "../../partials/DocumentTitle";
 import { Route, Switch } from "react-router-dom";
 import SchemaWizard from "../containers/SchemaWizard";
 import Notifications from "../notifications";
+import { Layout } from "antd";
 
 const AdminPanel = ({
   location,
@@ -49,9 +49,7 @@ const AdminPanel = ({
   return (
     <DocumentTitle title={getPageTitle()}>
       <Layout style={{ height: "100%", padding: 0 }}>
-        <Layout.Header style={{ padding: "0 10px" }}>
-          <Header />
-        </Layout.Header>
+        <Header />
         <Layout.Content>
           <Switch>
             <Route path={CMS_EDIT} component={SchemaWizard} />

--- a/ui/cap-react/src/antd/admin/components/Header.js
+++ b/ui/cap-react/src/antd/admin/components/Header.js
@@ -2,7 +2,7 @@ import React, { useState } from "react";
 import PropTypes from "prop-types";
 import JsonDiff from "./JSONDiff";
 import Form from "../../forms/Form";
-import { Button, Col, Menu, Modal, Row, Tabs, Grid } from "antd";
+import { Col, Menu, Modal, Row, Tabs, Grid } from "antd";
 import {
   ArrowLeftOutlined,
   DiffOutlined,
@@ -16,6 +16,7 @@ import { CMS } from "../../routes";
 import { configSchema } from "../utils/schemaSettings";
 import CodeViewer from "../../util/CodeViewer";
 import { json, jsonParseLinter } from "@codemirror/lang-json";
+import HeaderMenuItem from "./HeaderMenuItem/HeaderMenuItem";
 
 const { useBreakpoint } = Grid;
 const Header = ({
@@ -142,31 +143,28 @@ const Header = ({
         />
       </Modal>
 
-      <Col xs={8} md={4}>
-        <Button
-          icon={<ArrowLeftOutlined />}
-          onClick={() => pushPath(CMS)}
-          type="primary"
-        >
-          Admin Home Page
-        </Button>
+      <Col xs={4} lg={4} order={1}>
+        <Menu mode="horizontal" className="no-bottom-border">
+          <HeaderMenuItem
+            icon={<ArrowLeftOutlined />}
+            onClick={() => pushPath(CMS)}
+            label={screens.md && "Admin Home Page"}
+          />
+        </Menu>
       </Col>
-      <Col xs={16} md={10}>
+      <Col xs={{ span: 24, order: 3 }} sm={{ span: 11, order: 2 }} lg={7}>
         <Menu
-          theme="dark"
           mode="horizontal"
           selectedKeys={
             pathname.includes("/builder") ? ["builder"] : ["notifications"]
           }
-          style={{
-            justifyContent: "flex-end",
-          }}
+          style={{ justifyContent: screens.sm ? "flex-end" : "center" }}
         >
           <Menu.Item
             key="builder"
             icon={<FormOutlined />}
             onClick={() =>
-              pushPath(pathname.split("notifications")[0] + "builder")
+              pushPath(pathname.split(/notifications|builder/)[0] + "builder")
             }
           >
             Form Builder
@@ -175,40 +173,45 @@ const Header = ({
             key="notifications"
             icon={<NotificationOutlined />}
             onClick={() =>
-              pushPath(pathname.split("builder")[0] + "notifications")
+              pushPath(
+                pathname.split(/notifications|builder/)[0] + "notifications"
+              )
             }
           >
             Notifications
           </Menu.Item>
         </Menu>
       </Col>
-      <Col xs={24} md={10}>
+      <Col xs={{ span: 20, order: 2 }} sm={{ span: 9, order: 3 }} lg={13}>
         <Menu
           mode="horizontal"
-          theme="dark"
           selectable={false}
           style={{
-            justifyContent: screens.md ? "flex-end" : "center",
+            justifyContent: "flex-end",
           }}
+          className="no-bottom-border"
         >
-          <Menu.Item icon={<DownloadOutlined />} onClick={() => _getSchema()}>
-            Export Schema
-          </Menu.Item>
-          <Menu.Item
-            icon={<SaveOutlined />}
-            onClick={() => saveSchemaChanges()}
-          >
-            Save Updates
-          </Menu.Item>
-          <Menu.Item icon={<DiffOutlined />} onClick={() => setDiffModal(true)}>
-            Diff
-          </Menu.Item>
-          <Menu.Item
+          <HeaderMenuItem
+            icon={<DownloadOutlined />}
+            onClick={() => _getSchema()}
+            label="Export Schema"
+          />
+          <HeaderMenuItem
+            icon={<DiffOutlined />}
+            onClick={() => setDiffModal(true)}
+            label="Diff"
+          />
+          <HeaderMenuItem
             icon={<SettingOutlined />}
             onClick={() => setSettingsModal(true)}
-          >
-            Settings
-          </Menu.Item>
+            label="Settings"
+          />
+          <HeaderMenuItem
+            icon={<SaveOutlined />}
+            onClick={() => saveSchemaChanges()}
+            label="Save Updates"
+            type="primary"
+          />
         </Menu>
       </Col>
     </Row>

--- a/ui/cap-react/src/antd/admin/components/HeaderMenuItem/HeaderMenuItem.js
+++ b/ui/cap-react/src/antd/admin/components/HeaderMenuItem/HeaderMenuItem.js
@@ -1,0 +1,37 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Menu, Tooltip, Grid, Button } from "antd";
+import "./HeaderMenuItem.less";
+
+const { useBreakpoint } = Grid;
+
+const HeaderMenuItem = ({ icon, label, onClick, type }) => {
+  const screens = useBreakpoint();
+
+  return (
+    <Tooltip title={!screens.lg && label}>
+      <Menu.Item
+        icon={!type && icon}
+        onClick={!type && onClick}
+        className="no-bottom-border"
+        style={!screens.lg && { padding: "0 10px" }}
+      >
+        {type ? (
+          <Button icon={icon} type={type} onClick={onClick}>
+            {screens.lg && label}
+          </Button>
+        ) : (
+          screens.lg && label
+        )}
+      </Menu.Item>
+    </Tooltip>
+  );
+};
+
+HeaderMenuItem.propTypes = {
+  icon: PropTypes.element,
+  label: PropTypes.string,
+  onClick: PropTypes.func,
+};
+
+export default HeaderMenuItem;

--- a/ui/cap-react/src/antd/admin/components/HeaderMenuItem/HeaderMenuItem.less
+++ b/ui/cap-react/src/antd/admin/components/HeaderMenuItem/HeaderMenuItem.less
@@ -1,0 +1,5 @@
+.no-bottom-border {
+  .ant-menu-item::after {
+    border-bottom: none !important;
+  }
+}

--- a/ui/cap-react/src/antd/admin/containers/Header.js
+++ b/ui/cap-react/src/antd/admin/containers/Header.js
@@ -1,7 +1,7 @@
 import { connect } from "react-redux";
 import {
   saveSchemaChanges,
-  updateSchemaConfig
+  updateSchemaConfig,
 } from "../../../actions/schemaWizard";
 import { pushPath } from "../../../actions/support";
 import Header from "../components/Header";
@@ -13,7 +13,7 @@ function mapStateToProps(state) {
     initialSchema: state.schemaWizard.getIn(["initial", "schema"]),
     initialUiSchema: state.schemaWizard.getIn(["initial", "uiSchema"]),
     config: state.schemaWizard.get("config"),
-    pathname: state.router.location.pathname
+    pathname: state.router.location.pathname,
   };
 }
 
@@ -21,7 +21,7 @@ function mapDispatchToProps(dispatch) {
   return {
     saveSchemaChanges: () => dispatch(saveSchemaChanges()),
     pushPath: path => dispatch(pushPath(path)),
-    updateSchemaConfig: config => dispatch(updateSchemaConfig(config))
+    updateSchemaConfig: config => dispatch(updateSchemaConfig(config)),
   };
 }
 


### PR DESCRIPTION
Change the look of the admin toolbar to differentiate it from the app toolbar (and to improve a bit the looks on mobile, even though this is not our priority). Also fixed a bug that was causing the routing to break when clicking several times in a row in either "Form Builder" or "Notifications".

Signed-off-by: Miguel Garcia Garcia <miguel.garcia.garcia@cern.ch>