### PR TITLE
ui: fix MaskedInput component

### DIFF
--- a/cap/modules/fixtures/schemas/cms.json
+++ b/cap/modules/fixtures/schemas/cms.json
@@ -126,7 +126,6 @@
         "properties": {
           "cadi_id": {
             "pattern": "^[A-Z0-9]{3}-[0-9]{2}-[0-9]{3}$",
-            "mask": "***-00-000",
             "type": "string",
             "x-validate-cadi-id": {},
             "x-validate-unique-cadi":{},
@@ -327,7 +326,6 @@
           "ana_notes": {
             "items": {
               "pattern": "^AN-[0-9]{4}/[0-9]{3}$",
-              "mask":"\\AN-0000-000",
               "placeholder": "e.g. AN-2010-107",
               "type": "string"
             },
@@ -1135,6 +1133,7 @@
       "ui:order": ["cadi_id", "abstract", "conclusion", "*"],
       "cadi_id": {
         "ui:options": {
+          "mask": "***-00-000",
           "autofill_on": ["onClick", "onEnter"],
           "autofill_from": "/api/cms/cadi/",
           "autofill_fields": [
@@ -1157,7 +1156,12 @@
         "ui:widget": "textarea"
       },
       "ana_notes": {
-        "ui:array": "StringArrayField"
+        "ui:array": "StringArrayField",
+        "items": {
+          "ui:options": {
+            "mask":"\\AN-0000-000"
+          }
+        }
       }
     },
     "input_data": {

--- a/cap/modules/fixtures/schemas/cms.json
+++ b/cap/modules/fixtures/schemas/cms.json
@@ -126,6 +126,7 @@
         "properties": {
           "cadi_id": {
             "pattern": "^[A-Z0-9]{3}-[0-9]{2}-[0-9]{3}$",
+            "mask": "***-00-000",
             "type": "string",
             "x-validate-cadi-id": {},
             "x-validate-unique-cadi":{},
@@ -326,6 +327,7 @@
           "ana_notes": {
             "items": {
               "pattern": "^AN-[0-9]{4}/[0-9]{3}$",
+              "mask":"\\AN-0000-000",
               "placeholder": "e.g. AN-2010-107",
               "type": "string"
             },
@@ -1133,25 +1135,6 @@
       "ui:order": ["cadi_id", "abstract", "conclusion", "*"],
       "cadi_id": {
         "ui:options": {
-          "masked_array": [
-            {
-              "length": 3,
-              "regexp": "^[A-Z0-9]{1,3}$",
-              "placeholder": "XXX"
-            },
-            { "fixed": "-" },
-            {
-              "length": 2,
-              "regexp": "^[0-9]{1,2}$",
-              "placeholder": "XX"
-            },
-            { "fixed": "-" },
-            {
-              "length": 3,
-              "regexp": "^[0-9]{1,3}$",
-              "placeholder": "XXX"
-            }
-          ],
           "autofill_on": ["onClick", "onEnter"],
           "autofill_from": "/api/cms/cadi/",
           "autofill_fields": [
@@ -1174,27 +1157,7 @@
         "ui:widget": "textarea"
       },
       "ana_notes": {
-        "ui:array": "StringArrayField",
-        "items": {
-          "ui:options": {
-            "masked_array": [
-              {
-                "fixed": "AN-"
-              },
-              {
-                "length": 4,
-                "regexp": "^[0-9]{1,4}$",
-                "placeholder": "XXXX"
-              },
-              { "fixed": "/" },
-              {
-                "length": 3,
-                "regexp": "^[0-9]{1,3}$",
-                "placeholder": "XXX"
-              }
-            ]
-          }
-        }
+        "ui:array": "StringArrayField"
       }
     },
     "input_data": {

--- a/cap/modules/fixtures/schemas/cms.json
+++ b/cap/modules/fixtures/schemas/cms.json
@@ -1133,7 +1133,8 @@
       "ui:order": ["cadi_id", "abstract", "conclusion", "*"],
       "cadi_id": {
         "ui:options": {
-          "mask": "***-00-000",
+          "convertToUppercase": true,
+          "mask": "AAA-00-000",
           "autofill_on": ["onClick", "onEnter"],
           "autofill_from": "/api/cms/cadi/",
           "autofill_fields": [

--- a/ui/cap-react/package.json
+++ b/ui/cap-react/package.json
@@ -92,6 +92,7 @@
     "react-dom": "^16.8.0",
     "react-dropzone": "^4.2.9",
     "react-icons": "3.9.0",
+    "react-input-mask": "3.0.0-alpha.2",
     "react-json-editor-ajrm": "2.5.9",
     "react-jsonschema-form": "v2.0.0-alpha.1",
     "react-lazylog": "4.3.2",

--- a/ui/cap-react/src/antd/admin/components/PropertyEditor.js
+++ b/ui/cap-react/src/antd/admin/components/PropertyEditor.js
@@ -60,7 +60,7 @@ const PropertyEditor = ({ path, renameId, enableCreateMode, deleteByPath }) => {
   );
 
   return (
-    <div style={{ display: "flex", flexDirection: "column" }}>
+    <div style={{ display: "flex", flexDirection: "column", width: "100%" }}>
       <PageHeader
         onBack={enableCreateMode}
         title="Show Fields"

--- a/ui/cap-react/src/antd/admin/utils/fieldTypes.js
+++ b/ui/cap-react/src/antd/admin/utils/fieldTypes.js
@@ -70,8 +70,6 @@ const extra = {
     readOnly: {
       type: "boolean",
       title: "Do you want this field to be read only?",
-      enum: [true, false],
-      enumNames: ["ReadOnly", "Editable"],
     },
   },
   optionsSchemaUiSchema: {
@@ -95,12 +93,25 @@ const simple = {
       properties: {
         ...common.optionsSchema,
         pattern: {
-          title:
-            "Provide a regex for your input, only when you want a strict format",
+          title: "Validation regex",
           description:
-            "In order to be active, you have to split your regex into parts in the Field Layout info",
+            "The input will be validated against this regex on form submission",
           type: "string",
           pattern: "^^[w]*$$",
+        },
+        mask: {
+          type: "string",
+          title: "Input mask",
+          description: (
+            <div>
+              Add a mask to visualize and limit the format of the input. Use the
+              following format: <strong>'0'</strong> (number),{" "}
+              <strong>'a'</strong> (lowercase letter), <strong>'A'</strong>{" "}
+              (uppercase letter), <strong>'*'</strong> (letter or number). You
+              can escape all these with <strong>'\'</strong>. The rest of the
+              characters will be treated as constants
+            </div>
+          ),
         },
         readOnly: extra.optionsSchema.readOnly,
       },
@@ -108,19 +119,10 @@ const simple = {
     optionsSchemaUiSchema: {
       readOnly: extra.optionsSchemaUiSchema.readOnly,
       pattern: {
-        "ui:options": {
-          masked_array: [
-            {
-              fixed: "^",
-              placeholder: "^",
-            },
-            {
-              regexp: "^.*$",
-              placeholder: "XXXX",
-            },
-            { fixed: "$", placeholder: "$" },
-          ],
-        },
+        "ui:placeholder": "^.*$",
+      },
+      mask: {
+        "ui:placeholder": "BN-000/aa",
       },
     },
     optionsUiSchema: {
@@ -137,51 +139,9 @@ const simple = {
               title: "Add a suggestion URL endpoint",
               description: "Provide an URL endpoint, to fetch data from there",
             },
-            masked_array: {
-              type: "array",
-              title: "Add step-by-step validation for your pattern",
-              description:
-                "Split the regex into parts, and you will have real time validation for each part while writting",
-              items: {
-                type: "object",
-                title: "Regex parts",
-                description:
-                  "Your input can be either a fixed a value or you can provide a regex expression",
-                oneOf: [
-                  {
-                    title: "Fixed input",
-                    properties: {
-                      fixed: {
-                        type: "string",
-                        title: "Provide the fixed input",
-                        description:
-                          "This input is required only when you want to define a fixed value",
-                      },
-                    },
-                  },
-                  {
-                    title: "Regex Input",
-                    properties: {
-                      regexp: {
-                        type: "string",
-                        title: "Provide the regexp of this part",
-                        pattern: "^^[w]*$$",
-                      },
-                      length: {
-                        type: "integer",
-                        title: "Provide the max length",
-                        description:
-                          "This is the max length of this input part",
-                      },
-                      placeholder: {
-                        type: "string",
-                        title: "Placeholder",
-                        description: "Give a placeholder for your input ",
-                      },
-                    },
-                  },
-                ],
-              },
+            convertToUppercase: {
+              type: "boolean",
+              title: "Convert input to uppercase",
             },
           },
         },
@@ -686,6 +646,17 @@ const simple = {
     icon: <ContainerOutlined />,
     description: "Text Area field",
     child: {},
+    optionsSchema: {
+      type: "object",
+      title: "TextArea Schema",
+      properties: {
+        ...common.optionsSchema,
+        readOnly: extra.optionsSchema.readOnly,
+      },
+    },
+    optionsSchemaUiSchema: {
+      readOnly: extra.optionsSchemaUiSchema.readOnly,
+    },
     optionsUiSchema: {
       type: "object",
       title: "UI Schema",
@@ -723,17 +694,6 @@ const simple = {
     },
     optionsUiSchemaUiSchema: {
       ...common.optionsUiSchemaUiSchema,
-    },
-    optionsSchema: {
-      type: "object",
-      title: "TextArea Schema",
-      properties: {
-        ...common.optionsSchema,
-        readOnly: extra.optionsSchema.readOnly,
-      },
-    },
-    optionsSchemaUiSchema: {
-      readOnly: extra.optionsSchemaUiSchema.readOnly,
     },
     default: {
       schema: {

--- a/ui/cap-react/src/antd/admin/utils/fieldTypes.js
+++ b/ui/cap-react/src/antd/admin/utils/fieldTypes.js
@@ -99,20 +99,7 @@ const simple = {
           type: "string",
           pattern: "^^[w]*$$",
         },
-        mask: {
-          type: "string",
-          title: "Input mask",
-          description: (
-            <div>
-              Add a mask to visualize and limit the format of the input. Use the
-              following format: <strong>'0'</strong> (number),{" "}
-              <strong>'a'</strong> (lowercase letter), <strong>'A'</strong>{" "}
-              (uppercase letter), <strong>'*'</strong> (letter or number). You
-              can escape all these with <strong>'\'</strong>. The rest of the
-              characters will be treated as constants
-            </div>
-          ),
-        },
+        
         readOnly: extra.optionsSchema.readOnly,
       },
     },
@@ -120,9 +107,6 @@ const simple = {
       readOnly: extra.optionsSchemaUiSchema.readOnly,
       pattern: {
         "ui:placeholder": "^.*$",
-      },
-      mask: {
-        "ui:placeholder": "BN-000/aa",
       },
     },
     optionsUiSchema: {
@@ -143,12 +127,32 @@ const simple = {
               type: "boolean",
               title: "Convert input to uppercase",
             },
+            mask: {
+              type: "string",
+              title: "Input mask",
+              description: (
+                <div>
+                  Add a mask to visualize and limit the format of the input. Use the
+                  following format: <strong>'0'</strong> (number),{" "}
+                  <strong>'a'</strong> (lowercase letter), <strong>'A'</strong>{" "}
+                  (uppercase letter), <strong>'*'</strong> (letter or number). You
+                  can escape all these with <strong>'\'</strong>. The rest of the
+                  characters will be treated as constants
+                </div>
+              ),
+            },
           },
         },
       },
     },
     optionsUiSchemaUiSchema: {
       ...common.optionsUiSchemaUiSchema,
+      "ui:options": {
+        ...common.optionsUiSchemaUiSchema["ui:options"],
+        mask: {
+          "ui:placeholder": "BN-000/aa",
+        },
+      },
     },
     default: {
       schema: {

--- a/ui/cap-react/src/antd/admin/utils/fieldTypes.js
+++ b/ui/cap-react/src/antd/admin/utils/fieldTypes.js
@@ -99,7 +99,6 @@ const simple = {
           type: "string",
           pattern: "^^[w]*$$",
         },
-        
         readOnly: extra.optionsSchema.readOnly,
       },
     },
@@ -130,16 +129,8 @@ const simple = {
             mask: {
               type: "string",
               title: "Input mask",
-              description: (
-                <div>
-                  Add a mask to visualize and limit the format of the input. Use the
-                  following format: <strong>'0'</strong> (number),{" "}
-                  <strong>'a'</strong> (lowercase letter), <strong>'A'</strong>{" "}
-                  (uppercase letter), <strong>'*'</strong> (letter or number). You
-                  can escape all these with <strong>'\'</strong>. The rest of the
-                  characters will be treated as constants
-                </div>
-              ),
+              description:
+                "Add a mask to visualize and limit the format of the input. Use the following format: `0` (number), `a` (lowercase letter), `A` (uppercase letter), `*` (letter or number). You can escape all these with `\\`. The rest of the characters will be treated as constants",
             },
           },
         },
@@ -151,6 +142,9 @@ const simple = {
         ...common.optionsUiSchemaUiSchema["ui:options"],
         mask: {
           "ui:placeholder": "BN-000/aa",
+          "ui:options": {
+            descriptionIsMarkdown: true,
+          },
         },
       },
     },

--- a/ui/cap-react/src/antd/forms/widgets/MaskedInput/MaskedInput.js
+++ b/ui/cap-react/src/antd/forms/widgets/MaskedInput/MaskedInput.js
@@ -1,313 +1,69 @@
-import React, {
-  forwardRef,
-  // useCallback,
-  // useEffect,
-  // useRef,
-  // useState
-} from "react";
+import React from "react";
 
 import { Input } from "antd";
+import InputMask from "react-input-mask";
 
-// const parseValue = (mask, value) => {
-//   // break the value up into mask parts
-//   const valueParts = []; // { part, beginIndex, endIndex }
-//   let valueIndex = 0;
-//   let maskIndex = 0;
+const MAPPINGS = {
+  a: /[a-z]/,
+  A: /[A-Z]/,
+  "0": /[0-9]/,
+  "*": /[a-zA-Z0-9]/,
+};
 
-//   while (
-//     value !== undefined &&
-//     value !== null &&
-//     valueIndex < value.length &&
-//     maskIndex < mask.length
-//   ) {
-//     const item = mask[maskIndex];
+const MaskedInput = ({
+  id,
+  mask,
+  pattern,
+  name,
+  onBlur,
+  onChange,
+  onFocus,
+  onPressEnter,
+  placeholder,
+  buttons,
+  value,
+  disabled,
+  message,
+}) => {
+  const status = new RegExp(pattern).test(value);
 
-//     let found;
-//     if (item.fixed) {
-//       const { length } = item.fixed;
-
-//       // grab however much of value (starting at valueIndex) matches
-//       // item.fixed. If none matches it and there is more in value
-//       // add in the fixed item.
-//       let matching = 0;
-//       while (
-//         matching < length &&
-//         value[valueIndex + matching] === item.fixed[matching]
-//       ) {
-//         matching += 1;
-//       }
-
-//       if (matching > 0) {
-//         let part = value.slice(valueIndex, valueIndex + matching);
-//         if (valueIndex + matching < value.length) {
-//           // matched part of the fixed portion but there's more stuff
-//           // after it. Go ahead and fill in the entire fixed chunk
-//           part = item.fixed;
-//         }
-//         valueParts.push({
-//           part,
-//           beginIndex: valueIndex,
-//           endIndex: valueIndex + matching - 1
-//         });
-//         valueIndex += matching;
-//       } else {
-//         valueParts.push({
-//           part: item.fixed,
-//           beginIndex: valueIndex,
-//           endIndex: valueIndex + length - 1
-//         });
-//       }
-
-//       maskIndex += 1;
-//       found = true;
-//     } else if (item.options) {
-//       // reverse assuming larger is later
-//       found = item.options
-//         .slice(0)
-//         .reverse()
-//         // eslint-disable-next-line no-loop-func
-//         .some(option => {
-//           const { length } = option;
-//           const part = value.slice(valueIndex, valueIndex + length);
-//           if (part === option) {
-//             valueParts.push({
-//               part,
-//               beginIndex: valueIndex,
-//               endIndex: valueIndex + length - 1
-//             });
-//             valueIndex += length;
-//             maskIndex += 1;
-//             return true;
-//           }
-//           return false;
-//         });
-//     }
-//     if (!found) {
-//       if (item.regexp) {
-//         const minLength =
-//           (Array.isArray(item.length) && item.length[0]) || item.length || 1;
-//         const maxLength =
-//           (Array.isArray(item.length) && item.length[1]) ||
-//           item.length ||
-//           value.length - valueIndex;
-
-//         let length = maxLength;
-
-//         while (!found && length >= minLength) {
-//           // make sure that if the regex needs capidatl letters
-//           // then transform them to upperCase so then is provided an easier UX
-//           const part =
-//             item.regexp.includes("A-Z") && !item.regexp.includes("a-z")
-//               ? value.slice(valueIndex, valueIndex + length).toUpperCase()
-//               : value.slice(valueIndex, valueIndex + length);
-
-//           let reg = new RegExp(item.regexp);
-
-//           if (reg.test(part)) {
-//             valueParts.push({
-//               part,
-//               beginIndex: valueIndex,
-//               endIndex: valueIndex + length - 1
-//             });
-//             valueIndex += length;
-//             maskIndex += 1;
-//             found = true;
-//           }
-//           length -= 1;
-//         }
-//         if (!found) {
-//           valueIndex = value.length;
-//         }
-//       } else {
-//         const length = Array.isArray(item.length)
-//           ? item.length[1]
-//           : item.length || value.length - valueIndex;
-//         const part = value.slice(valueIndex, valueIndex + length);
-//         valueParts.push({
-//           part,
-//           beginIndex: valueIndex,
-//           endIndex: valueIndex + length - 1
-//         });
-//         valueIndex += length;
-//         maskIndex += 1;
-//       }
-//     }
-//   }
-//   return valueParts;
-// };
-
-const version = [
-  {
-    regexp: "^.*$",
-  },
-];
-
-const defaultMask = version;
-
-const MaskedInput = forwardRef(
-  ({
-    a11yTitle,
-    focus,
-    // focus: focusProp,
-    icon,
-    id,
-    mask = defaultMask,
-    name,
-    onBlur,
-    // schemaMask,
-    onChange,
-    onFocus,
-    onPressEnter,
-    placeholder,
-    plain,
-    buttons,
-    reverse,
-    value,
-    disabled,
-    message,
-    ...rest
-  }) => {
-    // const [value, setValue] = useState(valueProp);
-
-    // const [valueParts, setValueParts] = useState(parseValue(mask, value));
-    // useEffect(
-    //   () => {
-    //     setValueParts(parseValue(mask, value));
-    //   },
-    //   [mask, value]
-    // );
-
-    // const inputRef = useRef(null);
-
-    // const [focus, setFocus] = useState(focusProp);
-    // const [activeMaskIndex, setActiveMaskIndex] = useState();
-
-    // useEffect(
-    //   () => {
-    //     if (focus) {
-    //       const timer = setTimeout(() => {
-    //         // determine which mask element the caret is at
-    //         const caretIndex = inputRef.current.selectionStart;
-    //         let maskIndex;
-    //         valueParts.some((part, index) => {
-    //           if (
-    //             part.beginIndex <= caretIndex &&
-    //             part.endIndex >= caretIndex
-    //           ) {
-    //             maskIndex = index;
-    //             return true;
-    //           }
-    //           return false;
-    //         });
-    //         if (maskIndex === undefined && valueParts.length < mask.length) {
-    //           maskIndex = valueParts.length; // first unused one
-    //         }
-    //         if (maskIndex && mask[maskIndex].fixed) {
-    //           maskIndex -= 1; // fixed mask parts are never "active"
-    //         }
-    //         if (maskIndex !== activeMaskIndex) {
-    //           setActiveMaskIndex(maskIndex);
-    //         }
-    //       }, 10); // 10ms empirically chosen
-    //       return () => clearTimeout(timer);
-    //     }
-    //     return undefined;
-    //   },
-    //   [activeMaskIndex, focus, inputRef, mask, valueParts]
-    // );
-
-    // const setInputValue = useCallback(
-    //   nextValue => {
-    //     // Calling set value function directly on input because React library
-    //     // overrides setter `event.target.value =` and loses original event
-    //     // target fidelity.
-    //     // https://stackoverflow.com/a/46012210 &&
-    //     const nativeInputValueSetter = Object.getOwnPropertyDescriptor(
-    //       window.HTMLInputElement.prototype,
-    //       "value"
-    //     ).set;
-    //     nativeInputValueSetter.call(inputRef.current.input, nextValue);
-
-    //     const event = new Event("input", { bubbles: true });
-    //     inputRef.current.input.dispatchEvent(event);
-    //   },
-    //   [inputRef]
-    // );
-
-    // // This could be due to a paste or as the user is typing.
-    // const onChangeInput = useCallback(
-    //   event => {
-    //     // Align with the mask.
-
-    //     const nextValueParts = parseValue(mask, event.target.value);
-    //     const nextValue = nextValueParts.map(part => part.part).join("");
-
-    //     if (nextValue !== event.target.value) {
-    //       // The mask required inserting something, change the input.
-    //       // This will re-trigger this callback with the next value
-    //       setInputValue(nextValue);
-    //     } else if (value !== nextValue) {
-    //       setValue(nextValue);
-    //       if (onChange) onChange(event);
-    //     }
-    //   },
-    //   [mask, onChange, setInputValue, setValue, value]
-    // );
-
-    const renderPlaceholder = () => {
-      return mask.map((item) => item.placeholder || item.fixed).join("");
-    };
-
-    // const status = new RegExp(schemaMask).test(value);
-
-    return (
-      <div>
+  return (
+    <div>
+      <InputMask
+        mask={
+          mask &&
+          mask
+            .split(/(.*?[^\\])/)
+            .filter(i => i)
+            .map(i => (i in MAPPINGS ? MAPPINGS[i] : i.replace("\\", "")))
+        }
+        onChange={onChange}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        onPressEnter={onPressEnter}
+        value={value}
+        disabled={disabled}
+      >
         <Input
-          disabled={disabled}
-          // ref={inputRef}
-          aria-label={a11yTitle}
           id={id}
           name={name}
+          placeholder={placeholder}
           autoComplete="off"
-          plain={plain}
-          placeholder={placeholder || renderPlaceholder()}
-          icon={icon}
-          reverse={reverse}
-          focus={focus}
-          {...rest}
-          value={value}
-          onPressEnter={onPressEnter}
-          // onFocus={event => {
-          //   setFocus(true);
-
-          //   if (onFocus) onFocus(event);
-          // }}
-          // onBlur={event => {
-          //   if (status) {
-          //     if (!onBlur) return;
-          //     setFocus(false);
-          //     onBlur(event);
-          //   }
-          // }}
-          // onChange={onChangeInput}
-          onFocus={onFocus}
-          onBlur={onBlur}
-          onChange={onChange}
           suffix={buttons && buttons(status)}
         />
-        {message && (
-          <div
-            style={{
-              marginLeft: "5px",
-              color: message.status == "success" ? "green" : "#ff4d4f",
-            }}
-          >
-            {message.message}
-          </div>
-        )}
-      </div>
-    );
-  }
-);
+      </InputMask>
+      {message && (
+        <div
+          style={{
+            marginLeft: "5px",
+            color: message.status == "success" ? "green" : "#ff4d4f",
+          }}
+        >
+          {message.message}
+        </div>
+      )}
+    </div>
+  );
+};
 
 export default MaskedInput;

--- a/ui/cap-react/src/antd/forms/widgets/MaskedInput/MaskedInput.js
+++ b/ui/cap-react/src/antd/forms/widgets/MaskedInput/MaskedInput.js
@@ -24,6 +24,7 @@ const MaskedInput = ({
   value,
   disabled,
   message,
+  convertToUppercase,
 }) => {
   const status = new RegExp(pattern).test(value);
 
@@ -34,8 +35,13 @@ const MaskedInput = ({
           mask &&
           mask
             .split(/(.*?[^\\])/)
-            .filter(i => i)
-            .map(i => (i in MAPPINGS ? MAPPINGS[i] : i.replace("\\", "")))
+            .filter(i => i) // needed to remove empty entries
+            .map(i => {
+              let mappings = convertToUppercase
+                ? { ...MAPPINGS, a: /[a-zA-Z]/, A: /[a-zA-Z]/ }
+                : MAPPINGS;
+              return i in mappings ? mappings[i] : i.replace("\\", "");
+            })
         }
         onChange={onChange}
         onFocus={onFocus}

--- a/ui/cap-react/src/antd/forms/widgets/TextWidget.js
+++ b/ui/cap-react/src/antd/forms/widgets/TextWidget.js
@@ -55,15 +55,6 @@ const TextWidget = ({
     false
   );
 
-  const _replace_hash_with_current_indexes = path => {
-    let indexes = id.split("_").filter(item => !isNaN(item)),
-      index_cnt = 0;
-
-    return path.map(item => {
-      if (!isNaN(item)) ++index_cnt;
-      return item;
-    });
-  };
   const autoFillOtherFields = event => {
     let url = options.autofill_from,
       fieldsMap = options.autofill_fields,
@@ -76,11 +67,7 @@ const TextWidget = ({
       return;
 
     fieldsMap.map(el => {
-      let destination = el[1];
-
-      // replace # with current path
-      destination = _replace_hash_with_current_indexes(destination);
-      newFormData = newFormData.setIn(destination, undefined);
+      newFormData = newFormData.setIn(el[1], undefined);
     });
     formDataChange(newFormData.toJS());
 
@@ -94,12 +81,7 @@ const TextWidget = ({
           let _data = fromJS(data);
 
           fieldsMap.map(el => {
-            let source = el[0],
-              destination = el[1];
-
-            // replace # with current path
-            destination = _replace_hash_with_current_indexes(destination);
-            newFormData = newFormData.setIn(destination, _data.getIn(source));
+            newFormData = newFormData.setIn(el[1], _data.getIn(el[0]));
           });
 
           formDataChange(newFormData.toJS());

--- a/ui/cap-react/src/antd/forms/widgets/TextWidget.js
+++ b/ui/cap-react/src/antd/forms/widgets/TextWidget.js
@@ -22,6 +22,7 @@ const TextWidget = ({
   placeholder,
   readonly,
   schema,
+  uiSchema,
   value,
   formDataChange,
   formData,
@@ -29,6 +30,8 @@ const TextWidget = ({
   const { readonlyAsDisabled = true } = formContext;
 
   const { autofill_from, autofill_on, convertToUppercase } = options;
+
+  const mask = uiSchema && uiSchema["ui:options"] && uiSchema["ui:options"].mask
 
   const handleNumberChange = nextValue => onChange(nextValue);
 
@@ -55,6 +58,17 @@ const TextWidget = ({
     false
   );
 
+  const _replace_hash_with_current_indexes = (path) => {
+    let indexes = id.split("_").filter((item) => !isNaN(item)),
+      index_cnt = 0;
+
+    return path.map((item) => {
+      item = item === "#" ? indexes[index_cnt] : item;
+      if (!isNaN(item)) ++index_cnt;
+      return item;
+    });
+  };
+
   const autoFillOtherFields = event => {
     let url = options.autofill_from,
       fieldsMap = options.autofill_fields,
@@ -66,8 +80,10 @@ const TextWidget = ({
     )
       return;
 
-    fieldsMap.map(el => {
-      newFormData = newFormData.setIn(el[1], undefined);
+    fieldsMap.map((el) => {
+      // replace # with current path
+      let destination = _replace_hash_with_current_indexes(el[1]);
+      newFormData = newFormData.setIn(destination, undefined);
     });
     formDataChange(newFormData.toJS());
 
@@ -150,7 +166,7 @@ const TextWidget = ({
       placeholder={placeholder}
       value={value}
       pattern={schema.pattern}
-      mask={schema.mask}
+      mask={mask}
       message={message}
       buttons={
         autofill_from &&

--- a/ui/cap-react/src/antd/forms/widgets/TextWidget.js
+++ b/ui/cap-react/src/antd/forms/widgets/TextWidget.js
@@ -22,16 +22,13 @@ const TextWidget = ({
   placeholder,
   readonly,
   schema,
-  uiSchema,
   value,
   formDataChange,
   formData,
 }) => {
   const { readonlyAsDisabled = true } = formContext;
 
-  const { autofill_from, autofill_on, convertToUppercase } = options;
-
-  const mask = uiSchema && uiSchema["ui:options"] && uiSchema["ui:options"].mask
+  const { autofill_from, autofill_on, convertToUppercase, mask } = options;
 
   const handleNumberChange = nextValue => onChange(nextValue);
 
@@ -58,11 +55,11 @@ const TextWidget = ({
     false
   );
 
-  const _replace_hash_with_current_indexes = (path) => {
-    let indexes = id.split("_").filter((item) => !isNaN(item)),
+  const _replace_hash_with_current_indexes = path => {
+    let indexes = id.split("_").filter(item => !isNaN(item)),
       index_cnt = 0;
 
-    return path.map((item) => {
+    return path.map(item => {
       item = item === "#" ? indexes[index_cnt] : item;
       if (!isNaN(item)) ++index_cnt;
       return item;
@@ -80,7 +77,7 @@ const TextWidget = ({
     )
       return;
 
-    fieldsMap.map((el) => {
+    fieldsMap.map(el => {
       // replace # with current path
       let destination = _replace_hash_with_current_indexes(el[1]);
       newFormData = newFormData.setIn(destination, undefined);
@@ -97,7 +94,9 @@ const TextWidget = ({
           let _data = fromJS(data);
 
           fieldsMap.map(el => {
-            newFormData = newFormData.setIn(el[1], _data.getIn(el[0]));
+            // replace # with current path
+            let destination = _replace_hash_with_current_indexes(el[1]);
+            newFormData = newFormData.setIn(destination, _data.getIn(el[0]));
           });
 
           formDataChange(newFormData.toJS());
@@ -167,6 +166,7 @@ const TextWidget = ({
       value={value}
       pattern={schema.pattern}
       mask={mask}
+      convertToUppercase={convertToUppercase}
       message={message}
       buttons={
         autofill_from &&

--- a/ui/cap-react/src/antd/forms/widgets/TextWidget.js
+++ b/ui/cap-react/src/antd/forms/widgets/TextWidget.js
@@ -6,6 +6,7 @@ import { fromJS } from "immutable";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
 import { formDataChange } from "../../../actions/draftItem";
+
 const INPUT_STYLE = {
   width: "100%",
 };
@@ -27,12 +28,20 @@ const TextWidget = ({
 }) => {
   const { readonlyAsDisabled = true } = formContext;
 
-  const handleNumberChange = (nextValue) => onChange(nextValue);
+  const { autofill_from, autofill_on, convertToUppercase } = options;
+
+  const handleNumberChange = nextValue => onChange(nextValue);
 
   const handleTextChange = ({ target }) => {
     apiCalledWithCurrentState && setApiCalledWithCurrentState(false);
     message && setMessage(null);
-    onChange(target.value === "" ? options.emptyValue : target.value);
+    onChange(
+      target.value === ""
+        ? options.emptyValue
+        : convertToUppercase
+          ? target.value.toUpperCase()
+          : target.value
+    );
   };
 
   const handleBlur = ({ target }) => onBlur(id, target.value);
@@ -42,20 +51,20 @@ const TextWidget = ({
   const [message, setMessage] = useState(null);
 
   const [apiCalling, setApiCalling] = useState(false);
-  const [apiCalledWithCurrentState, setApiCalledWithCurrentState] =
-    useState(false);
+  const [apiCalledWithCurrentState, setApiCalledWithCurrentState] = useState(
+    false
+  );
 
-  const _replace_hash_with_current_indexes = (path) => {
-    let indexes = id.split("_").filter((item) => !isNaN(item)),
+  const _replace_hash_with_current_indexes = path => {
+    let indexes = id.split("_").filter(item => !isNaN(item)),
       index_cnt = 0;
 
-    return path.map((item) => {
-      item = item === "#" ? indexes[index_cnt] : item;
+    return path.map(item => {
       if (!isNaN(item)) ++index_cnt;
       return item;
     });
   };
-  const autoFillOtherFields = (event) => {
+  const autoFillOtherFields = event => {
     let url = options.autofill_from,
       fieldsMap = options.autofill_fields,
       newFormData = fromJS(formData);
@@ -66,7 +75,7 @@ const TextWidget = ({
     )
       return;
 
-    fieldsMap.map((el) => {
+    fieldsMap.map(el => {
       let destination = el[1];
 
       // replace # with current path
@@ -84,7 +93,7 @@ const TextWidget = ({
         if (Object.keys(data).length !== 0) {
           let _data = fromJS(data);
 
-          fieldsMap.map((el) => {
+          fieldsMap.map(el => {
             let source = el[0],
               destination = el[1];
 
@@ -107,7 +116,7 @@ const TextWidget = ({
           });
         }
       })
-      .catch((err) => {
+      .catch(err => {
         setApiCalling(false);
         setMessage({
           status: "error",
@@ -120,16 +129,6 @@ const TextWidget = ({
         });
       });
   };
-
-  const {
-    autofill_from,
-    autofill_on,
-    masked_array = [
-      {
-        regexp: "^.*$",
-      },
-    ],
-  } = options;
 
   return schema.type === "number" || schema.type === "integer" ? (
     <InputNumber
@@ -167,17 +166,15 @@ const TextWidget = ({
       }
       onFocus={!readonly ? handleFocus : undefined}
       placeholder={placeholder}
-      style={INPUT_STYLE}
-      type={options.inputType || "text"}
       value={value}
-      schemaMask={schema.pattern}
-      mask={masked_array}
+      pattern={schema.pattern}
+      mask={schema.mask}
       message={message}
       buttons={
         autofill_from &&
         autofill_on &&
         autofill_on.includes("onClick") &&
-        ((enabled) => (
+        (enabled => (
           <Button
             type="primary"
             disabled={!enabled || readonly}
@@ -192,12 +189,12 @@ const TextWidget = ({
   );
 };
 
-const mapStateToProps = (state) => ({
+const mapStateToProps = state => ({
   formData: state.draftItem.get("formData"),
 });
 
-const mapDispatchToProps = (dispatch) => ({
-  formDataChange: (data) => dispatch(formDataChange(data)),
+const mapDispatchToProps = dispatch => ({
+  formDataChange: data => dispatch(formDataChange(data)),
 });
 
 TextWidget.propTypes = {
@@ -216,4 +213,7 @@ TextWidget.propTypes = {
   onFocus: PropTypes.func,
 };
 
-export default connect(mapStateToProps, mapDispatchToProps)(TextWidget);
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(TextWidget);


### PR DESCRIPTION
Closes #2678.

Fixed the MaskedInput component. Using now the `react-masked-input` library, with some customizations on top.
The mask is a string and can be made of fixed characters and the following special placeholder characters: 

- `a`: lowercase letter
- `A`: uppercase letter
- `0`: number
- `*`: letter or number

Those four characters can be escaped with `\` in case we want to have them as fixed.
The component is prepared to be further customized if needed (as it has been already adapted to add the uppercase letter requirement and to replace the default 9 with a 0 for numbers) by means of regex mappings.
I've updated the fixture for the CMS schema so that it uses the new format for the masking. We need to see if more updates are required in the schemas that are already deployed in CAP @pamfilos 

**Extra:**

- Added a new boolean option in the UI Schema which, if enabled, will transform to uppercase all the text input into a field.
- Fixed root field's UI options panel not growing horizontally.