### PR TITLE
ui: fix overflow in schema tree item

### DIFF
--- a/ui/cap-react/src/actions/schemaWizard.js
+++ b/ui/cap-react/src/actions/schemaWizard.js
@@ -92,7 +92,7 @@ export function selectProperty(path) {
 }
 
 export function initSchemaWizard(data) {
-  return function (dispatch) {
+  return function(dispatch) {
     const { id, deposit_schema, deposit_options, ...configs } = data;
 
     configs.config = merge(configs.config, NOTIFICATIONS);
@@ -113,11 +113,11 @@ export function getSchema(name, version = null) {
   if (version)
     schemaLink = `/api/jsonschemas/${name}/${version}?resolve=1&config=1`;
   else schemaLink = `/api/jsonschemas/${name}?resolve=1&config=1`;
-  return function (dispatch) {
+  return function(dispatch) {
     dispatch(schemaInitRequest());
     axios
       .get(schemaLink)
-      .then((resp) => {
+      .then(resp => {
         let schema = resp.data;
         let { id, deposit_schema, deposit_options, ...configs } = schema;
 
@@ -132,7 +132,7 @@ export function getSchema(name, version = null) {
             )
           );
       })
-      .catch((err) => {
+      .catch(err => {
         dispatch(push(CMS));
         notification.error({
           message: "Schema fetch failed",
@@ -144,14 +144,14 @@ export function getSchema(name, version = null) {
 }
 
 export function getSchemasLocalStorage() {
-  return function () {
+  return function() {
     //let availableSchemas = localStorage.getItem("availableSchemas");
     let availableSchemas = JSON.parse(availableSchemas);
   };
 }
 
 export function createContentType(content_type) {
-  return function (dispatch) {
+  return function(dispatch) {
     dispatch(schemaInitRequest());
 
     let { name, description } = content_type;
@@ -166,18 +166,18 @@ export function createContentType(content_type) {
 }
 
 export function selectContentType(id) {
-  return function (dispatch) {
+  return function(dispatch) {
     dispatch(push(`${CMS}/${id}/builder`));
   };
 }
 
 export function selectFieldType(path, change) {
-  return function (dispatch) {
+  return function(dispatch) {
     dispatch(updateByPath(path, change));
   };
 }
 export function updateCurrentSchemaWithField(schema) {
-  return function (dispatch, getState) {
+  return function(dispatch, getState) {
     let state = getState().schemaWizard;
     let propKey = state.getIn(["field", "propKey"]);
     let path = state.getIn(["field", "path"]).toJS();
@@ -219,7 +219,7 @@ export function updateByPath(path, value) {
 }
 
 export function addByPath({ schema: path, uiSchema: uiPath }, data) {
-  return function (dispatch, getState) {
+  return function(dispatch, getState) {
     let schema = getState()
       .schemaWizard.getIn(["current", "schema", ...path])
       .toJS();
@@ -227,7 +227,9 @@ export function addByPath({ schema: path, uiSchema: uiPath }, data) {
     let _path = path;
     let _uiPath = uiPath;
 
-    let random_name = `item_${Math.random().toString(36).substring(2, 8)}`;
+    let random_name = `item_${Math.random()
+      .toString(36)
+      .substring(2, 8)}`;
 
     if (schema.type) {
       if (schema.type == "object") {
@@ -262,7 +264,7 @@ export function addProperty(path, key) {
 
 // delete item from schema and uiSchema
 export function deleteByPath(item) {
-  return function (dispatch, getState) {
+  return function(dispatch, getState) {
     const { path, uiPath } = item;
     const uiItemToDelete = uiPath.pop();
 
@@ -287,7 +289,7 @@ export function deleteByPath(item) {
     if (uiSchema["ui:order"]) {
       // remove the itemToDelete from the ui:order
       uiSchema["ui:order"] = uiSchema["ui:order"].filter(
-        (item) => item !== uiItemToDelete
+        item => item !== uiItemToDelete
       );
     }
 
@@ -301,7 +303,7 @@ export function deleteByPath(item) {
 
 // update the id field of a property
 export function renameIdByPath(item, newName) {
-  return function (dispatch, getState) {
+  return function(dispatch, getState) {
     const path = item.path;
     const uiPath = item.uiPath;
 
@@ -316,6 +318,11 @@ export function renameIdByPath(item, newName) {
       notification.warning({
         description: "Make sure that the new id is different and not empty",
       });
+      return;
+    }
+
+    if (newName.indexOf(" ") >= 0) {
+      notification.warning({ description: "An id cannot contain spaces" });
       return;
     }
 
@@ -379,7 +386,7 @@ export function createNotificationCategory(category) {
 }
 
 export function createNewNotification(category) {
-  return function (dispatch, getState) {
+  return function(dispatch, getState) {
     const valuesPath = [
       "config",
       "config",
@@ -406,7 +413,7 @@ export function createNewNotification(category) {
 }
 
 export function removeNotification(index, category) {
-  return function (dispatch, getState) {
+  return function(dispatch, getState) {
     const path = ["config", "config", "notifications", "actions", category];
 
     let notification = getState().schemaWizard.getIn(path);
@@ -419,7 +426,7 @@ export function removeNotification(index, category) {
 }
 
 export function updateNotificationData(data, id, category) {
-  return function (dispatch) {
+  return function(dispatch) {
     const valuesPath = [
       "config",
       "config",
@@ -434,7 +441,7 @@ export function updateNotificationData(data, id, category) {
 }
 
 export function saveSchemaChanges() {
-  return function (dispatch, getState) {
+  return function(dispatch, getState) {
     const state = getState();
     const config = state.schemaWizard.get("config");
     const pathname = state.router.location.pathname;
@@ -477,7 +484,7 @@ export function saveSchemaChanges() {
     if (pathname.startsWith(CMS_NEW) || isSchemaUpdated) {
       return axios
         .post("/api/jsonschemas", sendData)
-        .then((res) => {
+        .then(res => {
           const { deposit_options, deposit_schema, ...configs } = res.data;
           configs.config = merge(configs.config, NOTIFICATIONS);
           dispatch(
@@ -498,7 +505,7 @@ export function saveSchemaChanges() {
             )
           );
         })
-        .catch((err) => {
+        .catch(err => {
           let errorHeading, errorMessage;
           if (typeof err.response.data.message === "object") {
             let errMsg = Object.entries(err.response.data.message);

--- a/ui/cap-react/src/antd/admin/formComponents/SchemaTreeItem.js
+++ b/ui/cap-react/src/antd/admin/formComponents/SchemaTreeItem.js
@@ -23,7 +23,7 @@ import {
   UnorderedListOutlined,
   UpOutlined,
 } from "@ant-design/icons";
-import { Row, Space, Tag, Typography } from "antd";
+import { Col, Row, Tag, Typography } from "antd";
 import { isItTheArrayField } from "../utils";
 
 const SchemaTreeItem = ({
@@ -83,32 +83,57 @@ const SchemaTreeItem = ({
           0.5,
       }}
     >
-      <Row justify="space-between" align="middle">
-        <Space onClick={_onClick}>
-          {getIconByType(uiSchema, schema)}
-          <Typography.Text>{schema.title || "Untitled field"}</Typography.Text>
-          <Typography.Text type="secondary">
-            {path.schema[path.schema.length - 1]}
-          </Typography.Text>
-        </Space>
-        {schema ? (
-          <div>
-            {schema.type == "object" && !shouldBoxAcceptChildren(uiSchema) ? (
-              display ? (
-                <UpOutlined onClick={updateDisplay} />
-              ) : (
-                <DownOutlined onClick={updateDisplay} />
-              )
-            ) : null}
-            {isItTheArrayField(schema, uiSchema) ? (
-              display ? (
-                <UpOutlined onClick={updateDisplay} />
-              ) : (
-                <DownOutlined onClick={updateDisplay} />
-              )
-            ) : null}
-          </div>
-        ) : null}
+      <Row gutter={8} onClick={_onClick} align="middle" wrap={false}>
+        <Col flex="none">{getIconByType(uiSchema, schema)}</Col>
+        <Col flex="auto">
+          <Row
+            style={{ width: "100%", marginTop: schema.title ? "-9px" : "0" }}
+            justify="space-between"
+            wrap={false}
+            gutter={8}
+          >
+            <Col>
+              <Typography.Text ellipsis>
+                {path.schema[path.schema.length - 1]}
+              </Typography.Text>
+            </Col>
+          </Row>
+          {schema.title && (
+            <Row
+              style={{ width: "100%", marginTop: "-9px", marginBottom: "-9px" }}
+            >
+              <Col>
+                <Typography.Text
+                  type="secondary"
+                  style={{ fontSize: "10px" }}
+                  ellipsis
+                >
+                  {schema.title || "Untitled field"}
+                </Typography.Text>
+              </Col>
+            </Row>
+          )}
+        </Col>
+        <Col>
+          {schema ? (
+            <div>
+              {schema.type == "object" && !shouldBoxAcceptChildren(uiSchema) ? (
+                display ? (
+                  <UpOutlined onClick={updateDisplay} />
+                ) : (
+                  <DownOutlined onClick={updateDisplay} />
+                )
+              ) : null}
+              {isItTheArrayField(schema, uiSchema) ? (
+                display ? (
+                  <UpOutlined onClick={updateDisplay} />
+                ) : (
+                  <DownOutlined onClick={updateDisplay} />
+                )
+              ) : null}
+            </div>
+          ) : null}
+        </Col>
       </Row>
     </Tag>
   );


### PR DESCRIPTION
Closes #2736 

- Now the primary text in the tree items is the key of the field, and the secondary text, which is now the title, has been moved to another line. The title will only be displayed when there is one.
- Added ellipsis to both texts and prevented them from overflowing
- Now it's not possible to add spaces when editing the key. If you try adding them, the changes are not going to be saved and a warning will be displayed

<img width="1269" alt="Screen Shot 2023-02-28 at 13 26 59" src="https://user-images.githubusercontent.com/15983884/221869885-972017a7-69e6-4719-9ad5-18b6f5e6f4b4.png">
