### PR TITLE
ui: allow labels in multi checkbox and select

### DIFF
--- a/ui/cap-react/src/antd/admin/utils/fieldTypes.js
+++ b/ui/cap-react/src/antd/admin/utils/fieldTypes.js
@@ -404,11 +404,18 @@ const simple = {
                   enum: ["string"],
                 },
                 enum: {
-                  title: "Define your options",
+                  title: "Options",
                   type: "array",
-                  description: "The options for the widget",
                   items: {
-                    title: "Option",
+                    type: "string",
+                  },
+                },
+                enumNames: {
+                  title: "Labels",
+                  description:
+                    "If you want the labels to be different from the values, define them here in order",
+                  type: "array",
+                  items: {
                     type: "string",
                   },
                 },
@@ -420,11 +427,9 @@ const simple = {
                   enum: ["number"],
                 },
                 enum: {
-                  title: "Define your options",
+                  title: "Options",
                   type: "array",
-                  description: "The options for the widget",
                   items: {
-                    title: "Option",
                     type: "number",
                   },
                 },
@@ -440,9 +445,20 @@ const simple = {
                   title: "Define your options",
                   properties: {
                     enum: {
-                      title: "Options List",
+                      title: "Options",
                       type: "array",
-                      items: { type: "string", title: "Option" },
+                      items: {
+                        type: "string",
+                      },
+                    },
+                    enumNames: {
+                      title: "Labels",
+                      description:
+                        "If you want the labels to be different from the values, define them here in order",
+                      type: "array",
+                      items: {
+                        type: "string",
+                      },
                     },
                   },
                 },
@@ -617,13 +633,20 @@ const simple = {
                 items: {
                   title: "Define your options",
                   type: "object",
-                  description: "The options for the widget",
                   properties: {
                     enum: {
-                      title: "Options List",
+                      title: "Options",
                       type: "array",
                       items: {
-                        title: "Option",
+                        type: "string",
+                      },
+                    },
+                    enumNames: {
+                      title: "Labels",
+                      description:
+                        "If you want the labels to be different from the values, define them here in order",
+                      type: "array",
+                      items: {
                         type: "string",
                       },
                     },

--- a/ui/cap-react/src/antd/forms/Form.less
+++ b/ui/cap-react/src/antd/forms/Form.less
@@ -93,3 +93,7 @@
     resize: none;
   }
 }
+
+.layerListItem .ant-list-item-action li {
+  padding-right: 0;
+}

--- a/ui/cap-react/src/antd/forms/templates/ArrayFieldTemplates/ArrayFieldTemplateItem.js
+++ b/ui/cap-react/src/antd/forms/templates/ArrayFieldTemplates/ArrayFieldTemplateItem.js
@@ -16,16 +16,21 @@ const ArrayFieldTemplateItem = ({
   onReorderClick,
   readonly,
 }) => {
-  const { rowGutter = 24, toolbarAlign = "top" } = formContext;
+  const { toolbarAlign = "top" } = formContext;
 
   return (
     <Row
       align={toolbarAlign}
       key={`array-item-${index}`}
-      gutter={rowGutter}
-      style={{ marginTop: "24px", width: "100%" }}
+      style={{ margin: "10px 0px" }}
+      className="arrayFieldRow"
     >
-      <Col flex="1" style={{ borderBottom: "1px solid #f0f0f0" }}>
+      <Col
+        flex="1"
+        style={{
+          marginRight: "5px",
+        }}
+      >
         {children}
       </Col>
       {hasToolbar && (

--- a/ui/cap-react/src/antd/forms/templates/ArrayFieldTemplates/ArrayUtils.js
+++ b/ui/cap-react/src/antd/forms/templates/ArrayFieldTemplates/ArrayUtils.js
@@ -1,17 +1,9 @@
 import React from "react";
-import { Button, Col } from "antd";
+import { Button, Col, Row } from "antd";
 import ArrowUpOutlined from "@ant-design/icons/ArrowUpOutlined";
 import ArrowDownOutlined from "@ant-design/icons/ArrowDownOutlined";
 import DeleteOutlined from "@ant-design/icons/DeleteOutlined";
 import PropTypes from "prop-types";
-
-const BTN_GRP_STYLE = {
-  width: "100%",
-};
-
-// const BTN_STYLE = {
-//   width: "calc(100% / 3)",
-// };
 
 const ArrayUtils = ({
   hasMoveUp,
@@ -24,39 +16,46 @@ const ArrayUtils = ({
   hasRemove,
 }) => {
   return !readonly ? (
-    <Col flex="100px" style={{ padding: 0 }}>
-      <Button.Group style={{ ...BTN_GRP_STYLE, justifyContent: "end" }}>
+    <Col flex="none" style={{ padding: 0, margin: 0 }}>
+      <Row gutter={4}>
         {(hasMoveUp || hasMoveDown) && (
-          <Button
-            disabled={disabled || !hasMoveUp}
-            icon={<ArrowUpOutlined />}
-            onClick={onReorderClick(index, index - 1)}
-            // style={BTN_STYLE}
-            type="link"
-          />
+          <Col>
+            <Row>
+              <Button
+                disabled={disabled || !hasMoveUp}
+                icon={<ArrowUpOutlined style={{ fontSize: "14px" }} />}
+                onClick={onReorderClick(index, index - 1)}
+                type="link"
+                size="small"
+                style={{ height: "16px" }}
+              />
+            </Row>
+            <Row>
+              <Button
+                disabled={disabled || !hasMoveDown}
+                icon={<ArrowDownOutlined style={{ fontSize: "14px" }} />}
+                onClick={onReorderClick(index, index + 1)}
+                type="link"
+                size="small"
+                style={{ height: "16px" }}
+              />
+            </Row>
+          </Col>
         )}
-
-        {(hasMoveUp || hasMoveDown) && (
-          <Button
-            disabled={disabled || !hasMoveDown}
-            icon={<ArrowDownOutlined />}
-            onClick={onReorderClick(index, index + 1)}
-            // style={BTN_STYLE}
-            type="link"
-          />
-        )}
-
         {hasRemove && (
-          <Button
-            danger
-            disabled={disabled}
-            icon={<DeleteOutlined />}
-            onClick={onDropIndexClick(index)}
-            // style={BTN_STYLE}
-            type="link"
-          />
+          <Col>
+            <Button
+              danger
+              disabled={disabled}
+              icon={<DeleteOutlined />}
+              onClick={onDropIndexClick(index)}
+              type="link"
+              size="small"
+              style={{ height: "32px" }}
+            />
+          </Col>
         )}
-      </Button.Group>
+      </Row>
     </Col>
   ) : null;
 };

--- a/ui/cap-react/src/antd/forms/templates/ArrayFieldTemplates/LayerArrayFieldTemplate.js
+++ b/ui/cap-react/src/antd/forms/templates/ArrayFieldTemplates/LayerArrayFieldTemplate.js
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from "react";
 import PropTypes from "prop-types";
-import { Button, List, Modal, Typography } from "antd";
+import { Button, Col, List, Modal, Row, Typography } from "antd";
 
 import * as Sqrl from "squirrelly";
 
@@ -29,50 +29,66 @@ const LayerArrayFieldTemplate = ({ items = [] }) => {
 
     return stringify ? stringify.reduce(reducer, "") : null;
   };
-  useEffect(() => {
-    if (items && itemToDisplay)
-      setItemToDisplay({
-        index: itemToDisplay.index,
-        children: items[itemToDisplay.index].children,
-      });
-  }, [items]);
+  useEffect(
+    () => {
+      if (items && itemToDisplay)
+        setItemToDisplay({
+          index: itemToDisplay.index,
+          children: items[itemToDisplay.index].children,
+        });
+    },
+    [items]
+  );
 
-  const getActionsButtons = (item) => {
+  const getActionsButtons = item => {
     if (!item.hasToolbar) return [];
-    let toolbar = [];
-    if (item.hasMoveUp || item.hasMoveDown)
-      toolbar.push(
-        <Button
-          key="up"
-          icon={<ArrowUpOutlined />}
-          onClick={item.onReorderClick(item.index, item.index - 1)}
-          disabled={item.disabled || item.readonly || !item.hasMoveUp}
-        />
-      );
-    if (item.hasMoveUp || item.hasMoveDown)
-      toolbar.push(
-        <Button
-          key="down"
-          icon={<ArrowDownOutlined />}
-          onClick={item.onReorderClick(item.index, item.index + 1)}
-          disabled={item.disabled || item.readonly || !item.hasMoveDown}
-        />
-      );
 
-    if (item.hasRemove)
-      toolbar.push(
-        <Button
-          onClick={item.onDropIndexClick(item.index)}
-          key="delete"
-          danger
-          icon={<DeleteOutlined />}
-          disabled={item.disabled || item.readonly}
-          type="primary"
-        />
-      );
-
-    return toolbar;
+    return [
+      <Row gutter={4}>
+        {(item.hasMoveUp || item.hasMoveDown) && (
+          <Col>
+            <Row>
+              <Button
+                key="up"
+                icon={<ArrowUpOutlined style={{ fontSize: "14px" }} />}
+                onClick={item.onReorderClick(item.index, item.index - 1)}
+                disabled={item.disabled || item.readonly || !item.hasMoveUp}
+                type="link"
+                size="small"
+                style={{ height: "16px" }}
+              />
+            </Row>
+            <Row>
+              <Button
+                key="down"
+                icon={<ArrowDownOutlined style={{ fontSize: "14px" }} />}
+                onClick={item.onReorderClick(item.index, item.index + 1)}
+                disabled={item.disabled || item.readonly || !item.hasMoveDown}
+                type="link"
+                size="small"
+                style={{ height: "16px" }}
+              />
+            </Row>
+          </Col>
+        )}
+        {item.hasRemove && (
+          <Col>
+            <Button
+              onClick={item.onDropIndexClick(item.index)}
+              key="delete"
+              danger
+              icon={<DeleteOutlined />}
+              disabled={item.disabled || item.readonly}
+              type="link"
+              size="small"
+              style={{ height: "32px" }}
+            />
+          </Col>
+        )}
+      </Row>,
+    ];
   };
+
   if (items.length < 1) return null;
 
   return (
@@ -98,9 +114,12 @@ const LayerArrayFieldTemplate = ({ items = [] }) => {
         className="LayerArrayFieldList"
         style={{ overflow: "auto" }}
         dataSource={items}
-        renderItem={(item) => (
+        renderItem={item => (
           <ErrorFieldIndicator id={item.children.props.idSchema.$id}>
-            <List.Item actions={getActionsButtons(item)}>
+            <List.Item
+              className="layerListItem"
+              actions={getActionsButtons(item)}
+            >
               <List.Item.Meta
                 title={
                   <Typography.Text ellipsis={{ rows: 1 }}>

--- a/ui/cap-react/src/antd/forms/widgets/CheckboxWidget.js
+++ b/ui/cap-react/src/antd/forms/widgets/CheckboxWidget.js
@@ -58,7 +58,9 @@ const CheckboxWidget = ({
   } else {
     return (
       <Checkbox.Group
-        options={options.enumOptions.map(option => option.label)}
+        options={options.enumOptions.map(
+          option => (!option.value ? { ...option, value: "null" } : option)
+        )}
         autoFocus={autofocus}
         value={value || []}
         disabled={disabled || (readonlyAsDisabled && readonly)}


### PR DESCRIPTION
Closes #2713

- It's now possible to add labels to multi checkbox and select fields from the admin UI. If a label is provided, it will be displayed in the UI (it's only cosmetic), otherwise the value will be displayed. When sending the form, the value is sent in both cases. 
- The simplest way to implement it was to do it as two different arrays. It should be good enough at least for the time being.

---
- Also did a small change to layer and array fields so that the buttons are a bit more compact and allow to see the content when displayed in narrow parts as the PropKeyEditor. It now looks like this:

<img width="611" alt="Screen Shot 2023-03-02 at 11 22 56" src="https://user-images.githubusercontent.com/15983884/222504430-4e31cfff-986d-45d9-9672-95091f182b1f.png">
