### PR TITLE
ui: fix overflow and markdown in object titles

### DIFF
--- a/ui/cap-react/src/antd/forms/templates/ArrayFieldTemplates/FixedArrayFieldTemplate.js
+++ b/ui/cap-react/src/antd/forms/templates/ArrayFieldTemplates/FixedArrayFieldTemplate.js
@@ -1,20 +1,15 @@
 import React from "react";
-import classNames from "classnames";
 
 import { Row, Col, Button } from "antd";
 import { withConfigConsumer } from "antd/lib/config-provider/context";
 import PlusCircleOutlined from "@ant-design/icons/PlusCircleOutlined";
 import PropTypes from "prop-types";
 import ArrayFieldTemplateItem from "./ArrayFieldTemplateItem";
-
-const DESCRIPTION_COL_STYLE = {
-  paddingBottom: "8px",
-};
+import FieldHeader from "../Field/FieldHeader";
 
 const FixedArrayFieldTemplate = ({
   canAdd,
   className,
-  DescriptionField,
   disabled,
   formContext,
   // formData,
@@ -22,47 +17,23 @@ const FixedArrayFieldTemplate = ({
   items,
   options,
   onAddClick,
-  prefixCls,
   readonly,
   // registry,
-  required,
   schema,
   title,
-  TitleField,
   uiSchema,
 }) => {
-  const { labelAlign = "right", rowGutter = 24 } = formContext;
-
-  const labelClsBasic = `${prefixCls}-item-label`;
-  const labelColClassName = classNames(
-    labelClsBasic,
-    labelAlign === "left" && `${labelClsBasic}-left`
-    // labelCol.className,
-  );
+  const { rowGutter = 24 } = formContext;
 
   return (
     <fieldset className={className} id={idSchema.$id}>
       <Row gutter={rowGutter}>
-        {title && (
-          <Col className={labelColClassName} span={24} style={{ padding: "0" }}>
-            <TitleField
-              id={`${idSchema.$id}__title`}
-              key={`array-field-title-${idSchema.$id}`}
-              required={required}
-              title={uiSchema["ui:title"] || title}
-            />
-          </Col>
-        )}
-
-        {(uiSchema["ui:description"] || schema.description) && (
-          <Col span={24} style={DESCRIPTION_COL_STYLE}>
-            <DescriptionField
-              description={uiSchema["ui:description"] || schema.description}
-              id={`${idSchema.$id}-description`}
-              key={`array-field-description-${idSchema.$id}`}
-            />
-          </Col>
-        )}
+        <FieldHeader
+          label={uiSchema["ui:title"] || title}
+          isObject
+          description={uiSchema["ui:description"] || schema.description}
+          uiSchema={uiSchema}
+        />
 
         <Col span={24} style={{ marginTop: "5px" }} className="nestedObject">
           <Row>
@@ -105,7 +76,6 @@ const FixedArrayFieldTemplate = ({
 FixedArrayFieldTemplate.propTypes = {
   canAdd: PropTypes.bool,
   className: PropTypes.string,
-  DescriptionField: PropTypes.node,
   disabled: PropTypes.bool,
   formContext: PropTypes.object,
   idSchema: PropTypes.object,

--- a/ui/cap-react/src/antd/forms/templates/ArrayFieldTemplates/NormalArrayFieldTemplate.js
+++ b/ui/cap-react/src/antd/forms/templates/ArrayFieldTemplates/NormalArrayFieldTemplate.js
@@ -22,15 +22,11 @@ import {
   defaultHighlightStyle,
   StreamLanguage,
 } from "@codemirror/language";
-
-const DESCRIPTION_COL_STYLE = {
-  paddingBottom: "8px",
-};
+import FieldHeader from "../Field/FieldHeader";
 
 const NormalArrayFieldTemplate = ({
   canAdd,
   className,
-  DescriptionField,
   disabled,
   formContext,
   idSchema,
@@ -153,13 +149,10 @@ const NormalArrayFieldTemplate = ({
       : setSelectedEmailList(formData.map(user => user.profile.email));
   };
 
-  useEffect(
-    () => {
-      if (emailModal && formData.length != selectedEmailList.length)
-        setSelectedEmailList(formData.map(user => user.profile.email));
-    },
-    [emailModal]
-  );
+  useEffect(() => {
+    if (emailModal && formData.length != selectedEmailList.length)
+      setSelectedEmailList(formData.map(user => user.profile.email));
+  }, [emailModal]);
 
   return (
     <fieldset
@@ -219,69 +212,72 @@ const NormalArrayFieldTemplate = ({
           onCancel={() => setImportModal(false)}
         />
       )}
-      {uiEmail &&
-        formData && (
-          <Modal
-            visible={emailModal}
-            onCancel={() => setEmailModal(false)}
-            title="Select user & egroups emails to send"
-            okText="Send Email"
-            okType="link"
-            okButtonProps={{
-              href: `mailto:${uiEmailDefaults
-                .concat(selectedEmailList)
-                .join(",")}`,
-            }}
-            width={900}
-          >
-            <Space direction="vertical" style={{ width: "100%" }} size="large">
-              <Checkbox
-                onChange={() => updateEmailSelectedListAll()}
-                checked={formData.length === selectedEmailList.length}
-              >
-                Select all
-              </Checkbox>
-              {uiEmailDefaults.length > 0 ? (
-                <Col>
-                  Default email recepients:{" "}
-                  <Space>{uiEmailDefaults.map(i => <Tag>{i}</Tag>)}</Space>
-                </Col>
-              ) : null}
-              <Table
-                dataSource={formData.map(i => i.profile || i)}
-                columns={[
-                  {
-                    title: "Email User",
-                    key: "action",
-                    render: (_, user) => (
-                      <Checkbox
-                        checked={selectedEmailList.includes(user.email)}
-                        onChange={() => updateEmailSelectedList(user.email)}
-                      />
-                    ),
-                  },
-                  {
-                    title: "Name",
-                    dataIndex: "name",
-                    key: "name",
-                  },
-                  {
-                    title: "Email",
-                    dataIndex: "email",
-                    key: "email",
-                    render: txt => <Tag color="geekblue">{txt}</Tag>,
-                  },
-                  {
-                    title: "Department",
-                    dataIndex: "department",
-                    key: "department",
-                    render: txt => <Tag color="blue">{txt}</Tag>,
-                  },
-                ]}
-              />
-            </Space>
-          </Modal>
-        )}
+      {uiEmail && formData && (
+        <Modal
+          visible={emailModal}
+          onCancel={() => setEmailModal(false)}
+          title="Select user & egroups emails to send"
+          okText="Send Email"
+          okType="link"
+          okButtonProps={{
+            href: `mailto:${uiEmailDefaults
+              .concat(selectedEmailList)
+              .join(",")}`,
+          }}
+          width={900}
+        >
+          <Space direction="vertical" style={{ width: "100%" }} size="large">
+            <Checkbox
+              onChange={() => updateEmailSelectedListAll()}
+              checked={formData.length === selectedEmailList.length}
+            >
+              Select all
+            </Checkbox>
+            {uiEmailDefaults.length > 0 ? (
+              <Col>
+                Default email recepients:{" "}
+                <Space>
+                  {uiEmailDefaults.map(i => (
+                    <Tag>{i}</Tag>
+                  ))}
+                </Space>
+              </Col>
+            ) : null}
+            <Table
+              dataSource={formData.map(i => i.profile || i)}
+              columns={[
+                {
+                  title: "Email User",
+                  key: "action",
+                  render: (_, user) => (
+                    <Checkbox
+                      checked={selectedEmailList.includes(user.email)}
+                      onChange={() => updateEmailSelectedList(user.email)}
+                    />
+                  ),
+                },
+                {
+                  title: "Name",
+                  dataIndex: "name",
+                  key: "name",
+                },
+                {
+                  title: "Email",
+                  dataIndex: "email",
+                  key: "email",
+                  render: txt => <Tag color="geekblue">{txt}</Tag>,
+                },
+                {
+                  title: "Department",
+                  dataIndex: "department",
+                  key: "department",
+                  render: txt => <Tag color="blue">{txt}</Tag>,
+                },
+              ]}
+            />
+          </Space>
+        </Modal>
+      )}
       <Row gutter={rowGutter}>
         {title && (
           <Col className={labelColClassName} span={24} style={{ padding: "0" }}>
@@ -300,16 +296,10 @@ const NormalArrayFieldTemplate = ({
             />
           </Col>
         )}
-
-        {(uiSchema["ui:description"] || schema.description) && (
-          <Col span={24} style={{ ...DESCRIPTION_COL_STYLE, padding: "0" }}>
-            <DescriptionField
-              description={uiSchema["ui:description"] || schema.description}
-              id={`${idSchema.$id}__description`}
-              key={`array-field-description-${idSchema.$id}`}
-            />
-          </Col>
-        )}
+        <FieldHeader
+          description={uiSchema["ui:description"] || schema.description}
+          uiSchema={uiSchema}
+        />
         <Col span={24} style={{ marginTop: "5px" }} className="nestedObject">
           <Row>
             {items && (
@@ -329,26 +319,23 @@ const NormalArrayFieldTemplate = ({
             )}
           </Row>
         </Col>
-        {items &&
-          items.length > 0 &&
-          canAdd &&
-          !readonly && (
-            <Col span={24} style={{ marginTop: "10px" }}>
-              <Row gutter={rowGutter} justify="end">
-                <Col flex="192px">
-                  <Button
-                    block
-                    disabled={disabled || readonly}
-                    onClick={onAddClick}
-                    type="primary"
-                  >
-                    <PlusCircleOutlined /> Add{" "}
-                    {options && options.addLabel ? options.addLabel : `Item`}
-                  </Button>
-                </Col>
-              </Row>
-            </Col>
-          )}
+        {items && items.length > 0 && canAdd && !readonly && (
+          <Col span={24} style={{ marginTop: "10px" }}>
+            <Row gutter={rowGutter} justify="end">
+              <Col flex="192px">
+                <Button
+                  block
+                  disabled={disabled || readonly}
+                  onClick={onAddClick}
+                  type="primary"
+                >
+                  <PlusCircleOutlined /> Add{" "}
+                  {options && options.addLabel ? options.addLabel : `Item`}
+                </Button>
+              </Col>
+            </Row>
+          </Col>
+        )}
       </Row>
     </fieldset>
   );
@@ -357,7 +344,6 @@ const NormalArrayFieldTemplate = ({
 NormalArrayFieldTemplate.propTypes = {
   canAdd: PropTypes.bool,
   className: PropTypes.string,
-  DescriptionField: PropTypes.node,
   disabled: PropTypes.bool,
   formContext: PropTypes.object,
   idSchema: PropTypes.object,

--- a/ui/cap-react/src/antd/forms/templates/ArrayFieldTemplates/index.js
+++ b/ui/cap-react/src/antd/forms/templates/ArrayFieldTemplates/index.js
@@ -17,7 +17,6 @@ const {
 } = utils;
 
 const ArrayFieldTemplate = ({
-  DescriptionField,
   TitleField,
   autofocus,
   canAdd,
@@ -119,7 +118,6 @@ const ArrayFieldTemplate = ({
       <FixedArrayFieldTemplate
         canAdd={canAdd}
         className={className}
-        DescriptionField={DescriptionField}
         disabled={disabled}
         formContext={formContext}
         formData={formData}
@@ -150,7 +148,6 @@ const ArrayFieldTemplate = ({
     <NormalArrayFieldTemplate
       canAdd={canAdd}
       className={className}
-      DescriptionField={DescriptionField}
       disabled={disabled}
       formContext={formContext}
       formData={formData}
@@ -169,7 +166,6 @@ const ArrayFieldTemplate = ({
   );
 };
 ArrayFieldTemplate.propTypes = {
-  DescriptionField: PropTypes.node,
   TitleField: PropTypes.node,
   autofocus: PropTypes.bool,
   canAdd: PropTypes.bool,

--- a/ui/cap-react/src/antd/forms/templates/Field/FieldHeader.js
+++ b/ui/cap-react/src/antd/forms/templates/Field/FieldHeader.js
@@ -3,19 +3,21 @@ import PropTypes from "prop-types";
 import { Space, Typography } from "antd";
 import Markdown from "../../../partials/Markdown";
 
-const FieldHeader = ({ label, description, uiSchema }) => {
+const FieldHeader = ({ label, description, uiSchema, isObject }) => {
   return (
     <Space direction="vertical" size={0}>
-      <Typography.Text strong>
-        <Markdown
-          text={label}
-          style={{
-            color: "#000",
-          }}
-          renderAsHtml={
-            uiSchema["ui:options"] && uiSchema["ui:options"].titleIsMarkdown
-          }
-        />
+      <Typography.Text style={{ fontSize: isObject && "12pt" }} strong>
+        {label && (
+          <Markdown
+            text={label}
+            style={{
+              color: "#000",
+            }}
+            renderAsHtml={
+              uiSchema["ui:options"] && uiSchema["ui:options"].titleIsMarkdown
+            }
+          />
+        )}
       </Typography.Text>
       <Typography.Text type="secondary">
         {description && (
@@ -40,6 +42,7 @@ FieldHeader.propTypes = {
   label: PropTypes.string,
   uiSchema: PropTypes.object,
   description: PropTypes.node,
+  isObject: PropTypes.bool,
 };
 
 export default FieldHeader;

--- a/ui/cap-react/src/antd/forms/templates/ObjectFieldTemplate.js
+++ b/ui/cap-react/src/antd/forms/templates/ObjectFieldTemplate.js
@@ -2,18 +2,14 @@ import React from "react";
 import classNames from "classnames";
 import _ from "lodash";
 import { utils } from "@rjsf/core";
-import { Button, Col, Divider, Row } from "antd";
+import { Button, Col, Row } from "antd";
 import { PlusCircleOutlined } from "@ant-design/icons";
 import TabField from "./TabField";
 import PropTypes from "prop-types";
-import Text from "antd/lib/typography/Text";
+import FieldHeader from "./Field/FieldHeader";
 const { canExpand } = utils;
-const DESCRIPTION_COL_STYLE = {
-  paddingBottom: "8px",
-};
 
 const ObjectFieldTemplate = ({
-  DescriptionField,
   description,
   disabled,
   formContext,
@@ -83,65 +79,51 @@ const ObjectFieldTemplate = ({
   return (
     <fieldset style={{ margin: "0 12px" }} id={idSchema.$id}>
       <Row gutter={rowGutter}>
-        {uiSchema["ui:title"] !== false &&
-          (uiSchema["ui:title"] || title) && (
-            <Col
-              style={{
-                padding: "0",
-                marginBottom: "12px",
-              }}
-              className={labelColClassName}
-              span={24}
-            >
-              {
-                <Divider
-                  id={`${idSchema.$id}-title`}
-                  orientation="left"
-                  style={{ margin: 0 }}
-                >
-                  <Text strong>{uiSchema["ui:title"] || title}</Text>
-                </Divider>
-              }
-            </Col>
-          )}
-        {uiSchema["ui:description"] !== false &&
-          (uiSchema["ui:description"] || description) && (
-            <Col span={24} style={DESCRIPTION_COL_STYLE}>
-              <DescriptionField
-                description={uiSchema["ui:description"] || description}
-                id={`${idSchema.$id}-description`}
-              />
-            </Col>
-          )}
+        <Col
+          style={{
+            padding: "0",
+            marginBottom: "12px",
+          }}
+          className={labelColClassName}
+          span={24}
+        >
+          <FieldHeader
+            label={uiSchema["ui:title"] || title}
+            isObject
+            description={uiSchema["ui:description"] || description}
+            uiSchema={uiSchema}
+          />
+        </Col>
         <Col span={24} className="nestedObject">
           <Row gutter={10}>
-            {properties.filter(e => !e.hidden).map(element => (
-              <Col key={element.name} span={calculateColSpan(element)}>
-                {element.content}
-              </Col>
-            ))}
+            {properties
+              .filter(e => !e.hidden)
+              .map(element => (
+                <Col key={element.name} span={calculateColSpan(element)}>
+                  {element.content}
+                </Col>
+              ))}
           </Row>
         </Col>
       </Row>
 
-      {canExpand(schema, uiSchema, formData) &&
-        !readonly && (
-          <Col span={24}>
-            <Row gutter={rowGutter} justify="end">
-              <Col flex="192px">
-                <Button
-                  block
-                  className="object-property-expand"
-                  disabled={disabled}
-                  onClick={onAddClick(schema)}
-                  type="primary"
-                >
-                  <PlusCircleOutlined /> Add Item
-                </Button>
-              </Col>
-            </Row>
-          </Col>
-        )}
+      {canExpand(schema, uiSchema, formData) && !readonly && (
+        <Col span={24}>
+          <Row gutter={rowGutter} justify="end">
+            <Col flex="192px">
+              <Button
+                block
+                className="object-property-expand"
+                disabled={disabled}
+                onClick={onAddClick(schema)}
+                type="primary"
+              >
+                <PlusCircleOutlined /> Add Item
+              </Button>
+            </Col>
+          </Row>
+        </Col>
+      )}
     </fieldset>
   );
 };
@@ -160,7 +142,6 @@ ObjectFieldTemplate.propTypes = {
   title: PropTypes.string,
   uiSchema: PropTypes.object,
   properties: PropTypes.object,
-  DescriptionField: PropTypes.node,
   TitleField: PropTypes.node,
 };
 


### PR DESCRIPTION
Closes #2816 

Replaced Dividers from object field titles since they were causing issues with line breaks and added instead a normal, bigger size text. Also added markdown support there.