### PR TITLE
ui: add published date to preview header

### DIFF
--- a/cap/modules/fixtures/schemas/cms-questionnaire.json
+++ b/cap/modules/fixtures/schemas/cms-questionnaire.json
@@ -1830,6 +1830,9 @@
         "ui:order": ["options", "comments"]
       },
       "fitting_model": {
+        "comments": {
+          "ui:widget": "textarea"
+        },
         "ui:order": ["options", "comments"]
       },
       "stats": {

--- a/ui/cap-react/src/antd/drafts/components/DraftHeader/DraftHeader.js
+++ b/ui/cap-react/src/antd/drafts/components/DraftHeader/DraftHeader.js
@@ -39,7 +39,9 @@ const DraftHeader = ({
             newText.trim() != "" && updateGeneralTitle(newText)
           }
         />
-        {!canEdit(canAdmin, canUpdate) && <Tag color="gold">READ ONLY</Tag>}
+        {!canEdit(canAdmin, canUpdate) && (
+          <Tag color="gold-inverse">Read-only</Tag>
+        )}
       </Space>
       <Space size="middle">
         {!screens.lg && (

--- a/ui/cap-react/src/antd/published/components/Preview.js
+++ b/ui/cap-react/src/antd/published/components/Preview.js
@@ -4,12 +4,27 @@ import { transformSchema } from "../../partials/Utils/schema";
 import { COLLECTION_BASE } from "../../routes";
 import { shouldDisplayTabButton } from "../utils";
 import SideBar from "./SideBar";
-import { EditOutlined } from "@ant-design/icons";
-import { Space, Tag, Button, Row, Col, Radio, Grid, Layout } from "antd";
+import {
+  EditOutlined,
+  ExportOutlined,
+  InfoCircleOutlined,
+} from "@ant-design/icons";
+import {
+  Space,
+  Tag,
+  Button,
+  Row,
+  Col,
+  Radio,
+  Grid,
+  Layout,
+  Tooltip,
+} from "antd";
 import { PageHeader } from "@ant-design/pro-layout";
 import PropTypes from "prop-types";
 import { useState } from "react";
 import { Link } from "react-router-dom";
+import dayjs from "dayjs";
 
 const Preview = ({
   history,
@@ -21,6 +36,7 @@ const Preview = ({
   id,
   metadata = { general_title: "" },
   schemas = { schema: {}, uiSchema: {} },
+  updated,
 }) => {
   const [display, setDisplay] = useState(
     schemas.uiSchema["ui:object"] == "tabView" ? "tabView" : "list"
@@ -39,19 +55,36 @@ const Preview = ({
           <Space direction="vertical">
             {metadata.general_title}
             <Space style={{ width: "100%" }} wrap>
-              <Tag color="purple">Published</Tag>
-              <Tag>{id}</Tag>
+              <Tag bordered={false} color="purple-inverse">
+                Published
+              </Tag>
+              <Tag bordered={false} color="magenta">
+                {id}
+              </Tag>
               {schemaType && (
                 <Link
                   to={`${COLLECTION_BASE}/${schemaType.name}/${
                     schemaType.version || ""
                   }`}
                 >
-                  <Tag color="geekblue">
+                  <Tag
+                    bordered={false}
+                    color="geekblue"
+                    icon={<ExportOutlined />}
+                  >
                     {schemaType.fullname} v{schemaType.version}
                   </Tag>
                 </Link>
               )}
+              <Tooltip
+                title={`Last publication: ${dayjs(updated).format(
+                  "DD/MM/YYYY HH:mm:ss"
+                )}`}
+              >
+                <Tag bordered={false} icon={<InfoCircleOutlined />}>
+                  {dayjs(updated).format("DD/MM/YYYY")}
+                </Tag>
+              </Tooltip>
             </Space>
           </Space>
         }
@@ -146,6 +179,7 @@ Preview.propTypes = {
   canUpdate: PropTypes.bool,
   files: PropTypes.object,
   status: PropTypes.string,
+  updated: PropTypes.string,
 };
 
 export default Preview;

--- a/ui/cap-react/src/antd/published/containers/Preview.js
+++ b/ui/cap-react/src/antd/published/containers/Preview.js
@@ -10,12 +10,10 @@ const mapStateToProps = state => ({
   files: state.published.get("files"),
   schemas: state.published.get("schemas"),
   schemaType: state.published.get("schema"),
-  status: state.published.get("status")
+  status: state.published.get("status"),
+  updated: state.published.get("updated"),
 });
 
 const mapDispatchToProps = {};
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Preview);
+export default connect(mapStateToProps, mapDispatchToProps)(Preview);


### PR DESCRIPTION
Closes #2887 (and #2886)

<img width="578" alt="Screenshot 2024-04-26 at 16 38 57" src="https://github.com/cernanalysispreservation/analysispreservation.cern.ch/assets/15983884/f6c477f0-2133-4510-a8b6-b370fd50fa5e">
