### PR TITLE
Upgrade Nodejs to version 18

### DIFF
--- a/docker/harbour/ui/Dockerfile
+++ b/docker/harbour/ui/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update
 RUN apt-get install -y curl bash
 
 
-RUN curl -sL https://deb.nodesource.com/setup_16.x  | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x  | bash -
 RUN apt-get install -y nodejs
 
 RUN apt-get update && apt-get -y install  git python g++ make

--- a/docker/harbour/ui/Dockerfile
+++ b/docker/harbour/ui/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update
 RUN apt-get install -y curl bash
 
 
-RUN curl -sL https://deb.nodesource.com/setup_14.x  | bash -
+RUN curl -sL https://deb.nodesource.com/setup_16.x  | bash -
 RUN apt-get install -y nodejs
 
 RUN apt-get update && apt-get -y install  git python g++ make

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update
 RUN apt-get install -y curl bash
 
 
-RUN curl -sL https://deb.nodesource.com/setup_14.x  | bash -
+RUN curl -sL https://deb.nodesource.com/setup_16.x  | bash -
 RUN apt-get install -y nodejs
 
 RUN apt-get update && apt-get -y install  git python g++ make

--- a/docker/nginx/Dockerfile
+++ b/docker/nginx/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update
 RUN apt-get install -y curl bash
 
 
-RUN curl -sL https://deb.nodesource.com/setup_16.x  | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x  | bash -
 RUN apt-get install -y nodejs
 
 RUN apt-get update && apt-get -y install  git python g++ make


### PR DESCRIPTION
Motivation:

```
docker-compose -f docker-compose.full.yml build
...
28.43 warning eslint > file-entry-cache > flat-cache > rimraf@3.0.2: Rimraf versions prior to v4 are no longer supported
28.48 warning eslint > file-entry-cache > flat-cache > rimraf > glob@7.2.3: Glob versions prior to v9 are no longer supported
28.53 warning eslint > file-entry-cache > flat-cache > rimraf > glob > inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
29.69 warning prop-types > fbjs > core-js@1.2.7: core-js@<3.23.3 is no longer maintained and not recommended for usage due to the number of issues. Because of the V8 engine whims, feature detection in old core-js versions could cause a slowdown up to 100x even if nothing is polyfilled. Some versions have web compatibility issues. Please, upgrade your dependencies to the actual version of core-js.
29.98 warning replace > minimatch@0.2.14: Please update to minimatch 3.0.2 or higher to avoid a RegExp DoS issue
30.02 warning replace > nomnom@1.6.2: Package no longer supported. Contact support@npmjs.com for more info.
30.08 warning rimraf@2.6.1: Rimraf versions prior to v4 are no longer supported
30.08 warning rimraf > glob@7.2.3: Glob versions prior to v9 are no longer supported
31.32 [3/5] Fetching packages...
123.7 error type-fest@4.30.0: The engine "node" is incompatible with this module. Expected version ">=16". Got "14.21.3"
123.7 error Found incompatible module.
123.7 info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
------
failed to solve: process "/bin/sh -c yarn install" did not complete successfully: exit code: 1
```

Modification:

An upgrade to nodejs >=16 fixes this issue.